### PR TITLE
Add ledger repository with MySQL implementation and integration tests (T1.3)

### DIFF
--- a/.claude/agents/verify.md
+++ b/.claude/agents/verify.md
@@ -1,0 +1,62 @@
+---
+name: verify
+description: Run lint, build, and tests in a self-correcting loop until everything passes. Use proactively after code changes to verify correctness before committing.
+tools: Read, Edit, Bash, Grep, Glob
+model: inherit
+---
+
+You are a verification agent for a Go microservices project. Your job is to run the verification pipeline, fix any failures, and report results.
+
+## Pipeline
+
+Run these in order, stopping at the first failure:
+
+1. **Lint:** `make lint`
+2. **Build:** `make build`
+3. **Test:** `make test`
+
+## On failure: diagnose and fix
+
+When a step fails:
+
+1. Read the error output carefully.
+2. Identify the failing file(s) and line number(s).
+3. Read the relevant source code to understand context.
+4. Fix the issue:
+   - **Lint errors** — apply the fix directly (formatting, unused imports, error handling, etc.).
+   - **Build errors** — fix type errors, missing imports, syntax issues.
+   - **Test failures** — determine if the test or the implementation is wrong:
+     - If the test expectation is stale (doesn't match the current design), update the test.
+     - If the implementation has a bug, fix the implementation.
+     - If unsure, stop and report the ambiguity rather than guessing.
+5. After fixing, re-run the **full pipeline from step 1** (not just the failing step) to catch regressions.
+
+## Loop limit
+
+**Maximum 3 fix-and-retry cycles.** If the pipeline still fails after 3 attempts, stop and report:
+- Which step is failing
+- The exact error output
+- What was tried and why it didn't work
+- A recommendation for the user
+
+## On success
+
+When all steps pass, return a concise summary:
+
+```
+Verification passed:
+  Lint:  OK
+  Build: OK
+  Test:  OK (X passed, 0 failed)
+```
+
+Include the test count if visible in the output.
+
+## Rules
+
+- **Never skip a linter or disable a lint rule** to make it pass. Fix the underlying code.
+- **Never use `--no-verify`** or skip any checks.
+- **Never delete or skip a test** to make the suite pass.
+- If `make test` requires Docker services (MySQL, Redis) and they're not running, report that the user needs to run `make up` first.
+- Always wrap errors with context: `fmt.Errorf("doing thing: %w", err)`
+- Use `gofmt` and `goimports` formatting conventions.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,22 @@
 {
   "permissions": {
     "allow": [
-      "Bash(gh issue view:*)"
+      "Bash(make lint)",
+      "Bash(make test)",
+      "Bash(make build)",
+      "Bash(make fmt)",
+      "Bash(make proto)",
+      "Bash(go build:*)",
+      "Bash(go test:*)",
+      "Bash(go vet:*)",
+      "Bash(go mod tidy)",
+      "Bash(git:*)",
+      "Bash(gh issue:*)",
+      "Bash(gh pr:*)",
+      "Bash(docker-compose ps)",
+      "Bash(docker-compose logs:*)",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "WebSearch"
     ]
   },
   "hooks": {

--- a/.claude/skills/commit-push-pr/SKILL.md
+++ b/.claude/skills/commit-push-pr/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: commit-push-pr
+description: Stage, commit, push, and open a PR in one command
+user-invokable: true
+---
+
+# Commit, Push, PR
+
+Stage changed files, generate a commit message, push, and open a pull request — all in one invocation.
+
+## Usage
+
+`/commit-push-pr [optional commit message override]`
+
+Argument: $ARGUMENTS
+
+- If a message is provided, use it as the commit message.
+- If no argument, generate a message from the diff (see Step 2).
+
+## Instructions
+
+### Step 1 — Assess what changed
+
+1. Run `git status` to see staged, unstaged, and untracked files.
+2. Run `git diff` and `git diff --cached` to see the actual changes.
+3. Run `git branch --show-current` to get the branch name.
+4. Run `git log origin/master..HEAD --oneline` to see existing commits on this branch.
+
+**Important:**
+- Do NOT stage files that look like secrets (`.env`, credentials, tokens).
+- Do NOT stage binary files or build artifacts (`bin/`, `*.exe`).
+- If there are no changes to commit, tell the user and stop.
+
+### Step 2 — Stage and commit
+
+1. Stage relevant files by name (prefer `git add <file> <file>` over `git add -A`).
+2. Generate a commit message if one was not provided:
+   - Look at the diff to understand the nature of the change.
+   - Write a concise message (imperative mood, under 72 chars for subject).
+   - If there are multiple logical changes, use a subject line + bullet body.
+   - Follow commit style from `git log --oneline -10`.
+   - **Do NOT add Co-Authored-By or any AI attribution** (per CLAUDE.md).
+3. Show the user the proposed commit message and staged files before committing.
+4. Create the commit.
+
+### Step 3 — Push
+
+1. Check if the branch has an upstream: `git rev-parse --abbrev-ref @{upstream} 2>/dev/null`
+2. If no upstream, push with: `git push -u origin <branch-name>`
+3. If upstream exists, push with: `git push`
+
+### Step 4 — Open PR
+
+1. Check if a PR already exists for this branch: `gh pr view --json number 2>/dev/null`
+2. **If a PR already exists:** Tell the user the PR was updated with the new push and show the PR URL. Do NOT create a new PR.
+3. **If no PR exists:** Create one:
+   - Extract the issue number from the branch name (e.g. `6-t13-ledger-repository` → `#6`).
+   - Title: Use the GitHub issue title if available, otherwise derive from commits.
+   - Body format:
+
+```
+## Summary
+<3-5 bullet points describing what this PR does>
+
+## Changes
+<list of key files changed and why>
+
+## Test plan
+<how to verify — reference make test, specific test files, manual steps>
+
+Closes #<issue-number>
+```
+
+4. Create the PR: `gh pr create --title "..." --body "..."`
+5. Show the user the PR URL.
+
+### Step 5 — Confirm
+
+Report to the user:
+- What was committed (files + message)
+- The push result
+- The PR URL (new or existing)

--- a/.claude/skills/next-task/SKILL.md
+++ b/.claude/skills/next-task/SKILL.md
@@ -52,5 +52,5 @@ requirements to the user and ask if they are ready to begin.
 
 Tell the user:
 - What was written to the handoff
-- That they can now close this session and open a new one in the VSCode extension
+- That they can now close this session and start a new one (terminal or VSCode — both work)
 - The new session will automatically pick up from where we left off

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/go-sql-driver/mysql v1.9.3
 	github.com/golang-migrate/migrate/v4 v4.19.1
+	github.com/google/uuid v1.6.0
 	github.com/prometheus/client_golang v1.23.2
 	go.uber.org/zap v1.27.1
 	google.golang.org/grpc v1.78.0

--- a/internal/ledger/mysql_repository.go
+++ b/internal/ledger/mysql_repository.go
@@ -1,0 +1,262 @@
+package ledger
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+)
+
+// StatusPosted is the status value for a successfully committed transaction.
+const StatusPosted = "posted"
+
+// MySQLRepository implements Repository using a MySQL database.
+type MySQLRepository struct {
+	db     *sql.DB
+	logger *zap.Logger
+}
+
+// NewMySQLRepository creates a new MySQLRepository.
+func NewMySQLRepository(db *sql.DB, logger *zap.Logger) *MySQLRepository {
+	return &MySQLRepository{db: db, logger: logger}
+}
+
+// PostTransaction atomically records a double-entry transaction. If a
+// transaction with the same idempotency key already exists, the existing
+// transaction is returned without modification.
+func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (*Transaction, error) {
+	if err := tx.Validate(); err != nil {
+		return nil, fmt.Errorf("validating transaction: %w", err)
+	}
+
+	dbTx, err := r.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("beginning transaction: %w", err)
+	}
+	defer dbTx.Rollback()
+
+	// Idempotency check: return existing result if already posted.
+	existing, err := r.findByIdempotencyKey(ctx, dbTx, tx.IdempotencyKey)
+	if err != nil {
+		return nil, fmt.Errorf("checking idempotency: %w", err)
+	}
+	if existing != nil {
+		return existing, nil
+	}
+
+	// Collect and sort unique (account_id, asset) pairs for deterministic lock ordering.
+	type accountAsset struct {
+		accountID string
+		asset     string
+	}
+	seen := make(map[accountAsset]bool)
+	var pairs []accountAsset
+	for _, p := range tx.Postings {
+		key := accountAsset{string(p.AccountID), string(p.Asset)}
+		if !seen[key] {
+			seen[key] = true
+			pairs = append(pairs, key)
+		}
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].accountID != pairs[j].accountID {
+			return pairs[i].accountID < pairs[j].accountID
+		}
+		return pairs[i].asset < pairs[j].asset
+	})
+
+	// Lock and read balances. For each sorted pair, try to lock the existing
+	// row first. If it doesn't exist, insert a zero-balance row (which also
+	// acquires the lock). This avoids INSERT IGNORE gap locks that cause
+	// deadlocks under concurrency.
+	balances := make(map[AccountID]Amount)
+	for _, pair := range pairs {
+		var balance int64
+		err := dbTx.QueryRowContext(ctx,
+			`SELECT balance FROM ledger_balances WHERE account_id = ? AND asset = ? FOR UPDATE`,
+			pair.accountID, pair.asset,
+		).Scan(&balance)
+
+		if err == sql.ErrNoRows {
+			// Row doesn't exist yet — insert a zero-balance row.
+			if _, err := dbTx.ExecContext(ctx,
+				`INSERT INTO ledger_balances (account_id, asset, balance) VALUES (?, ?, 0)`,
+				pair.accountID, pair.asset,
+			); err != nil {
+				return nil, fmt.Errorf("inserting balance row %s/%s: %w", pair.accountID, pair.asset, err)
+			}
+			balance = 0
+		} else if err != nil {
+			return nil, fmt.Errorf("locking balance %s/%s: %w", pair.accountID, pair.asset, err)
+		}
+
+		balances[AccountID(pair.accountID)] = Amount(balance)
+	}
+
+	// Check overdraft using the domain logic. The balances map is keyed by
+	// AccountID alone, which is safe because Validate() enforces that all
+	// postings share the same asset (ErrAssetMismatch).
+	if err := tx.CheckOverdraft(balances); err != nil {
+		return nil, err
+	}
+
+	// Generate ID and timestamp.
+	tx.ID = uuid.NewString()
+	tx.CreatedAt = time.Now()
+
+	// Insert transaction row.
+	if _, err := dbTx.ExecContext(ctx,
+		`INSERT INTO ledger_transactions (tx_id, idempotency_key, reference, status, created_at)
+		 VALUES (?, ?, '', ?, ?)`,
+		tx.ID, tx.IdempotencyKey, StatusPosted, tx.CreatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("inserting transaction: %w", err)
+	}
+
+	// Insert entry rows (one per posting).
+	for _, p := range tx.Postings {
+		if _, err := dbTx.ExecContext(ctx,
+			`INSERT INTO ledger_entries (tx_id, account_id, amount, asset, created_at)
+			 VALUES (?, ?, ?, ?, ?)`,
+			tx.ID, string(p.AccountID), int64(p.Amount), string(p.Asset), tx.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("inserting entry for %s: %w", p.AccountID, err)
+		}
+	}
+
+	// Aggregate balance deltas per unique (account_id, asset) pair, then
+	// issue one UPDATE per pair in the same sorted order used for locking.
+	deltas := make(map[accountAsset]int64)
+	for _, p := range tx.Postings {
+		deltas[accountAsset{string(p.AccountID), string(p.Asset)}] += int64(p.Amount)
+	}
+	for _, pair := range pairs {
+		if _, err := dbTx.ExecContext(ctx,
+			`UPDATE ledger_balances SET balance = balance + ? WHERE account_id = ? AND asset = ?`,
+			deltas[pair], pair.accountID, pair.asset,
+		); err != nil {
+			return nil, fmt.Errorf("updating balance for %s/%s: %w", pair.accountID, pair.asset, err)
+		}
+	}
+
+	if err := dbTx.Commit(); err != nil {
+		return nil, fmt.Errorf("committing transaction: %w", err)
+	}
+
+	r.logger.Info("transaction posted",
+		zap.String("tx_id", tx.ID),
+		zap.String("idempotency_key", tx.IdempotencyKey),
+		zap.Int("postings", len(tx.Postings)),
+	)
+
+	return &tx, nil
+}
+
+// GetTransaction retrieves a transaction by its idempotency key.
+func (r *MySQLRepository) GetTransaction(ctx context.Context, idempotencyKey string) (*Transaction, error) {
+	var tx Transaction
+	err := r.db.QueryRowContext(ctx,
+		`SELECT tx_id, idempotency_key, created_at
+		 FROM ledger_transactions WHERE idempotency_key = ?`, idempotencyKey,
+	).Scan(&tx.ID, &tx.IdempotencyKey, &tx.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying transaction: %w", err)
+	}
+
+	postings, err := r.loadPostings(ctx, r.db, tx.ID)
+	if err != nil {
+		return nil, err
+	}
+	tx.Postings = postings
+
+	return &tx, nil
+}
+
+// GetBalance returns the current balance for an account and asset pair.
+func (r *MySQLRepository) GetBalance(ctx context.Context, accountID AccountID, asset Asset) (Amount, error) {
+	var balance int64
+	err := r.db.QueryRowContext(ctx,
+		`SELECT balance FROM ledger_balances WHERE account_id = ? AND asset = ?`,
+		string(accountID), string(asset),
+	).Scan(&balance)
+
+	if err == sql.ErrNoRows {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("querying balance for %s/%s: %w", accountID, asset, err)
+	}
+	return Amount(balance), nil
+}
+
+// findByIdempotencyKey checks if a transaction with the given key already
+// exists inside an active database transaction. Returns nil, nil if not found.
+func (r *MySQLRepository) findByIdempotencyKey(ctx context.Context, dbTx *sql.Tx, key string) (*Transaction, error) {
+	var tx Transaction
+	err := dbTx.QueryRowContext(ctx,
+		`SELECT tx_id, idempotency_key, created_at
+		 FROM ledger_transactions WHERE idempotency_key = ?`, key,
+	).Scan(&tx.ID, &tx.IdempotencyKey, &tx.CreatedAt)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying transaction by idempotency key: %w", err)
+	}
+
+	postings, err := r.loadPostings(ctx, dbTx, tx.ID)
+	if err != nil {
+		return nil, err
+	}
+	tx.Postings = postings
+
+	return &tx, nil
+}
+
+// queryable abstracts *sql.DB and *sql.Tx for shared query logic.
+type queryable interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// loadPostings loads the postings for a transaction from ledger_entries.
+func (r *MySQLRepository) loadPostings(ctx context.Context, q queryable, txID string) ([]Posting, error) {
+	rows, err := q.QueryContext(ctx,
+		`SELECT account_id, amount, asset
+		 FROM ledger_entries WHERE tx_id = ? ORDER BY entry_id`, txID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying entries for tx %s: %w", txID, err)
+	}
+	defer rows.Close()
+
+	var postings []Posting
+	for rows.Next() {
+		var (
+			accountID string
+			amount    int64
+			asset     string
+		)
+		if err := rows.Scan(&accountID, &amount, &asset); err != nil {
+			return nil, fmt.Errorf("scanning entry: %w", err)
+		}
+		postings = append(postings, Posting{
+			AccountID: AccountID(accountID),
+			Amount:    Amount(amount),
+			Asset:     Asset(asset),
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating entries: %w", err)
+	}
+
+	return postings, nil
+}

--- a/internal/ledger/mysql_repository_integration_test.go
+++ b/internal/ledger/mysql_repository_integration_test.go
@@ -1,0 +1,371 @@
+//go:build integration
+
+package ledger_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"sync"
+	"testing"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/golang-migrate/migrate/v4"
+	mysqlmigrate "github.com/golang-migrate/migrate/v4/database/mysql"
+	"github.com/golang-migrate/migrate/v4/source/iofs"
+	"go.uber.org/zap"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/ledger"
+	migrations "github.com/CLAM101/exchange-ledger-platform/migrations"
+)
+
+var testDB *sql.DB
+
+func TestMain(m *testing.M) {
+	dsn := buildTestDSN()
+
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		log.Fatalf("opening test database: %v", err)
+	}
+
+	if err := db.Ping(); err != nil {
+		log.Fatalf("pinging test database: %v", err)
+	}
+
+	if err := runMigrations(db); err != nil {
+		log.Fatalf("running migrations: %v", err)
+	}
+
+	testDB = db
+
+	code := m.Run()
+
+	db.Close()
+	os.Exit(code)
+}
+
+func buildTestDSN() string {
+	host := envOrDefault("DB_HOST", "localhost")
+	port := envOrDefault("DB_PORT", "3306")
+	user := envOrDefault("DB_USER", "ledger_user")
+	pass := envOrDefault("DB_PASSWORD", "ledger_pass")
+	name := envOrDefault("DB_NAME", "ledger")
+	return fmt.Sprintf("%s:%s@tcp(%s:%s)/%s?parseTime=true", user, pass, host, port, name)
+}
+
+func envOrDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func runMigrations(db *sql.DB) error {
+	source, err := iofs.New(migrations.FS, ".")
+	if err != nil {
+		return fmt.Errorf("creating migration source: %w", err)
+	}
+	driver, err := mysqlmigrate.WithInstance(db, &mysqlmigrate.Config{})
+	if err != nil {
+		return fmt.Errorf("creating migration driver: %w", err)
+	}
+	m, err := migrate.NewWithInstance("iofs", source, "mysql", driver)
+	if err != nil {
+		return fmt.Errorf("creating migrate instance: %w", err)
+	}
+	if err := m.Up(); err != nil && err != migrate.ErrNoChange {
+		return fmt.Errorf("running migrations: %w", err)
+	}
+	return nil
+}
+
+func truncateTables(t *testing.T) {
+	t.Helper()
+	// Order matters: entries has FK to transactions.
+	for _, stmt := range []string{
+		"DELETE FROM ledger_entries",
+		"DELETE FROM ledger_balances",
+		"DELETE FROM ledger_transactions",
+	} {
+		if _, err := testDB.ExecContext(context.Background(), stmt); err != nil {
+			t.Fatalf("truncating tables: %v", err)
+		}
+	}
+}
+
+func seedBalance(t *testing.T, accountID ledger.AccountID, asset ledger.Asset, amount ledger.Amount) {
+	t.Helper()
+	_, err := testDB.ExecContext(context.Background(),
+		`INSERT INTO ledger_balances (account_id, asset, balance) VALUES (?, ?, ?)
+		 ON DUPLICATE KEY UPDATE balance = balance + VALUES(balance)`,
+		string(accountID), string(asset), int64(amount),
+	)
+	if err != nil {
+		t.Fatalf("seeding balance for %s/%s: %v", accountID, asset, err)
+	}
+}
+
+func newRepo(t *testing.T) *ledger.MySQLRepository {
+	t.Helper()
+	return ledger.NewMySQLRepository(testDB, zap.NewNop())
+}
+
+// --- Test: Successful transaction posting ---
+
+func TestPostTransaction_Success(t *testing.T) {
+	truncateTables(t)
+	repo := newRepo(t)
+
+	seedBalance(t, "acc_source", "BTC", 10000)
+
+	tx := ledger.Transaction{
+		IdempotencyKey: "idem-success-1",
+		Postings: []ledger.Posting{
+			{AccountID: "acc_source", Asset: "BTC", Amount: -5000},
+			{AccountID: "acc_dest", Asset: "BTC", Amount: 5000},
+		},
+	}
+
+	result, err := repo.PostTransaction(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PostTransaction: %v", err)
+	}
+
+	if result.ID == "" {
+		t.Error("expected non-empty tx ID")
+	}
+	if result.IdempotencyKey != "idem-success-1" {
+		t.Errorf("idempotency key = %q, want %q", result.IdempotencyKey, "idem-success-1")
+	}
+	if result.CreatedAt.IsZero() {
+		t.Error("expected non-zero created_at")
+	}
+	if len(result.Postings) != 2 {
+		t.Fatalf("expected 2 postings, got %d", len(result.Postings))
+	}
+
+	// Verify balances were updated.
+	srcBal, err := repo.GetBalance(context.Background(), "acc_source", "BTC")
+	if err != nil {
+		t.Fatalf("GetBalance source: %v", err)
+	}
+	if srcBal != 5000 {
+		t.Errorf("source balance = %d, want 5000", srcBal)
+	}
+
+	dstBal, err := repo.GetBalance(context.Background(), "acc_dest", "BTC")
+	if err != nil {
+		t.Fatalf("GetBalance dest: %v", err)
+	}
+	if dstBal != 5000 {
+		t.Errorf("dest balance = %d, want 5000", dstBal)
+	}
+}
+
+// --- Test: Idempotency replay ---
+
+func TestPostTransaction_IdempotencyReplay(t *testing.T) {
+	truncateTables(t)
+	repo := newRepo(t)
+
+	seedBalance(t, "acc_src", "BTC", 10000)
+
+	tx := ledger.Transaction{
+		IdempotencyKey: "idem-replay-1",
+		Postings: []ledger.Posting{
+			{AccountID: "acc_src", Asset: "BTC", Amount: -1000},
+			{AccountID: "acc_dst", Asset: "BTC", Amount: 1000},
+		},
+	}
+
+	first, err := repo.PostTransaction(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("first post: %v", err)
+	}
+
+	second, err := repo.PostTransaction(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("second post: %v", err)
+	}
+
+	// Same transaction ID returned.
+	if first.ID != second.ID {
+		t.Errorf("tx IDs differ: %s vs %s", first.ID, second.ID)
+	}
+
+	// Balance only debited once.
+	bal, err := repo.GetBalance(context.Background(), "acc_src", "BTC")
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if bal != 9000 {
+		t.Errorf("balance = %d, want 9000 (debited only once)", bal)
+	}
+
+	// Only one transaction row exists.
+	var count int
+	if err := testDB.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM ledger_transactions WHERE idempotency_key = ?`,
+		"idem-replay-1",
+	).Scan(&count); err != nil {
+		t.Fatalf("counting transactions: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("transaction count = %d, want 1", count)
+	}
+}
+
+// --- Test: Overdraft prevention ---
+
+func TestPostTransaction_Overdraft(t *testing.T) {
+	truncateTables(t)
+	repo := newRepo(t)
+
+	seedBalance(t, "acc_poor", "BTC", 500)
+	seedBalance(t, "acc_rich", "BTC", 0)
+
+	tx := ledger.Transaction{
+		IdempotencyKey: "idem-overdraft-1",
+		Postings: []ledger.Posting{
+			{AccountID: "acc_poor", Asset: "BTC", Amount: -1000},
+			{AccountID: "acc_rich", Asset: "BTC", Amount: 1000},
+		},
+	}
+
+	_, err := repo.PostTransaction(context.Background(), tx)
+	if !errors.Is(err, ledger.ErrOverdraft) {
+		t.Fatalf("expected ErrOverdraft, got: %v", err)
+	}
+
+	// Verify no rows were created (atomic rollback).
+	var txCount int
+	if err := testDB.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM ledger_transactions WHERE idempotency_key = ?`,
+		"idem-overdraft-1",
+	).Scan(&txCount); err != nil {
+		t.Fatalf("counting transactions: %v", err)
+	}
+	if txCount != 0 {
+		t.Errorf("transaction count = %d, want 0 (rolled back)", txCount)
+	}
+
+	// Balance unchanged.
+	bal, err := repo.GetBalance(context.Background(), "acc_poor", "BTC")
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if bal != 500 {
+		t.Errorf("balance = %d, want 500 (unchanged)", bal)
+	}
+}
+
+// --- Test: Concurrent debits (race condition prevention) ---
+
+func TestPostTransaction_ConcurrentDebits(t *testing.T) {
+	truncateTables(t)
+	repo := newRepo(t)
+
+	// Account has exactly 1000 — only one of two 1000-debit transactions can succeed.
+	seedBalance(t, "acc_shared", "BTC", 1000)
+	seedBalance(t, "acc_dest_0", "BTC", 0)
+	seedBalance(t, "acc_dest_1", "BTC", 0)
+
+	var wg sync.WaitGroup
+	results := make(chan error, 2)
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			tx := ledger.Transaction{
+				IdempotencyKey: fmt.Sprintf("idem-concurrent-%d", idx),
+				Postings: []ledger.Posting{
+					{AccountID: "acc_shared", Asset: "BTC", Amount: -1000},
+					{AccountID: ledger.AccountID(fmt.Sprintf("acc_dest_%d", idx)), Asset: "BTC", Amount: 1000},
+				},
+			}
+			_, err := repo.PostTransaction(context.Background(), tx)
+			results <- err
+		}(i)
+	}
+
+	wg.Wait()
+	close(results)
+
+	var successes, overdrafts int
+	for err := range results {
+		if err == nil {
+			successes++
+		} else if errors.Is(err, ledger.ErrOverdraft) {
+			overdrafts++
+		} else {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+
+	if successes != 1 {
+		t.Errorf("successes = %d, want exactly 1", successes)
+	}
+	if overdrafts != 1 {
+		t.Errorf("overdrafts = %d, want exactly 1", overdrafts)
+	}
+
+	// Balance must be exactly 0 — never negative.
+	bal, err := repo.GetBalance(context.Background(), "acc_shared", "BTC")
+	if err != nil {
+		t.Fatalf("GetBalance: %v", err)
+	}
+	if bal != 0 {
+		t.Errorf("balance = %d, want 0 (never negative)", bal)
+	}
+}
+
+// --- Test: GetTransaction not found ---
+
+func TestGetTransaction_NotFound(t *testing.T) {
+	truncateTables(t)
+	repo := newRepo(t)
+
+	_, err := repo.GetTransaction(context.Background(), "nonexistent-key")
+	if !errors.Is(err, ledger.ErrNotFound) {
+		t.Fatalf("expected ErrNotFound, got: %v", err)
+	}
+}
+
+// --- Test: GetTransaction found ---
+
+func TestGetTransaction_Found(t *testing.T) {
+	truncateTables(t)
+	repo := newRepo(t)
+
+	seedBalance(t, "acc_a", "BTC", 5000)
+	seedBalance(t, "acc_b", "BTC", 0)
+
+	tx := ledger.Transaction{
+		IdempotencyKey: "idem-get-1",
+		Postings: []ledger.Posting{
+			{AccountID: "acc_a", Asset: "BTC", Amount: -1000},
+			{AccountID: "acc_b", Asset: "BTC", Amount: 1000},
+		},
+	}
+
+	posted, err := repo.PostTransaction(context.Background(), tx)
+	if err != nil {
+		t.Fatalf("PostTransaction: %v", err)
+	}
+
+	fetched, err := repo.GetTransaction(context.Background(), "idem-get-1")
+	if err != nil {
+		t.Fatalf("GetTransaction: %v", err)
+	}
+	if fetched.ID != posted.ID {
+		t.Errorf("ID = %q, want %q", fetched.ID, posted.ID)
+	}
+	if len(fetched.Postings) != 2 {
+		t.Errorf("postings count = %d, want 2", len(fetched.Postings))
+	}
+}

--- a/internal/ledger/repository.go
+++ b/internal/ledger/repository.go
@@ -1,0 +1,21 @@
+package ledger
+
+import "context"
+
+// Repository defines the persistence operations for the ledger.
+type Repository interface {
+	// PostTransaction atomically records a double-entry transaction.
+	// If a transaction with the same idempotency key already exists,
+	// the existing transaction is returned without modification.
+	// Returns ErrOverdraft if applying the postings would cause any
+	// account balance to go negative.
+	PostTransaction(ctx context.Context, tx Transaction) (*Transaction, error)
+
+	// GetTransaction retrieves a transaction by its idempotency key.
+	// Returns ErrNotFound if no transaction exists with the given key.
+	GetTransaction(ctx context.Context, idempotencyKey string) (*Transaction, error)
+
+	// GetBalance returns the current balance for an account and asset pair.
+	// Returns 0 if no balance row exists (account has never transacted).
+	GetBalance(ctx context.Context, accountID AccountID, asset Asset) (Amount, error)
+}

--- a/internal/ledger/validate.go
+++ b/internal/ledger/validate.go
@@ -13,6 +13,7 @@ var (
 	ErrAssetMismatch = errors.New("all postings must use the same asset")
 	ErrUnbalanced    = errors.New("postings must sum to zero")
 	ErrOverdraft     = errors.New("transaction would overdraft account")
+	ErrNotFound      = errors.New("not found")
 )
 
 // Validate checks the structural invariants of a transaction:


### PR DESCRIPTION
## Summary
- Define `Repository` interface with `PostTransaction`, `GetTransaction`, and `GetBalance` methods
- Implement `MySQLRepository` with atomic double-entry posting inside a single DB transaction
- Enforce overdraft prevention using `SELECT ... FOR UPDATE` row locks with deterministic lock ordering to prevent deadlocks
- Idempotency: duplicate idempotency keys return the existing transaction without double-posting
- Add 6 integration tests against real MySQL: success, idempotency replay, overdraft rejection, concurrent debit safety, GetTransaction found/not-found

## Changes
- `internal/ledger/repository.go` — new `Repository` interface
- `internal/ledger/mysql_repository.go` — MySQL implementation with atomic posting, locking, idempotency
- `internal/ledger/mysql_repository_integration_test.go` — integration tests (`//go:build integration`)
- `internal/ledger/validate.go` — added `ErrNotFound` sentinel
- `go.mod` — added `google/uuid` as direct dependency

## Test plan
- `go test -v ./internal/ledger/...` — unit tests pass
- `docker-compose up -d mysql && go run ./cmd/migrate up` — start MySQL + apply migrations
- `go test -v -tags=integration ./internal/ledger/...` — all 6 integration tests pass
- Concurrency test verifies two simultaneous debits against the same account: exactly one succeeds, balance never goes negative

Closes #6