### PR TITLE
Add ledger health checks and domain metrics (T1.5)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ docs/                   # conventions.md is the key reference
 
 ## Key Conventions
 
-**Read `docs/conventions.md` for full details.** Summary:
+**IMPORTANT: Always read `docs/conventions.md` before writing or reviewing code.** It is the authoritative style guide. Summary below is a quick reference only — defer to conventions.md when in doubt.
 
 ### Idempotency
 All write operations MUST accept an idempotency key. Check for existing results before processing.

--- a/cmd/account/main.go
+++ b/cmd/account/main.go
@@ -69,7 +69,7 @@ func run() error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 
-	grpcServer := platformgrpc.NewServer(logger, metrics)
+	grpcServer := platformgrpc.NewServer(logger, metrics, nil)
 
 	// TODO: Register service implementations
 	// accountpb.RegisterAccountServiceServer(grpcServer, accountService)

--- a/cmd/ledger/main.go
+++ b/cmd/ledger/main.go
@@ -16,12 +16,16 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/CLAM101/exchange-ledger-platform/internal/ledger"
 	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
 	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
 	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
 )
+
+const serviceName = "ledger"
 
 func main() {
 	if err := run(); err != nil {
@@ -33,7 +37,7 @@ func run() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	logger, err := observability.NewLogger("ledger")
+	logger, err := observability.NewLogger(serviceName)
 	if err != nil {
 		return fmt.Errorf("failed to create logger: %w", err)
 	}
@@ -41,7 +45,7 @@ func run() error {
 		_ = logger.Sync() //nolint:errcheck // Sync errors are acceptable in defer
 	}()
 
-	metrics := observability.NewMetrics("ledger")
+	metrics := observability.NewMetrics(serviceName)
 
 	go func() {
 		mux := http.NewServeMux()
@@ -84,7 +88,15 @@ func run() error {
 	}
 	logger.Info("connected to database")
 
-	repo := ledger.NewMySQLRepository(db, logger)
+	// Health service.
+	hs := health.NewServer()
+	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
+
+	dbChecker := platformgrpc.NewDBHealthChecker(db)
+	go platformgrpc.WatchHealth(ctx, hs, serviceName, dbChecker, 10*time.Second, logger)
+
+	repo := ledger.NewMySQLRepository(db, logger, metrics)
 	handler := ledger.NewServer(repo, logger)
 
 	port := getEnv("GRPC_PORT", "9001")
@@ -93,7 +105,7 @@ func run() error {
 		return fmt.Errorf("failed to listen: %w", err)
 	}
 
-	grpcServer := platformgrpc.NewServer(logger, metrics)
+	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
 	ledgerv1.RegisterLedgerServiceServer(grpcServer, handler)
 
 	logger.Info("Ledger service listening", zap.String("port", port))
@@ -109,6 +121,8 @@ func run() error {
 	select {
 	case <-ctx.Done():
 		logger.Info("context cancelled, shutting down")
+		hs.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+		hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
 		grpcServer.GracefulStop()
 		return nil
 	case err := <-errChan:

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -272,6 +272,25 @@ func (r *Repository) SaveTransaction(ctx context.Context, tx *Transaction) error
 }
 ```
 
+### Scanning Named Types
+
+When scanning SQL rows into structs that use named types (e.g. `type AccountID string`),
+scan directly into the named type field — do not use intermediate variables with manual conversion.
+Go's `database/sql` driver resolves the underlying type via reflection, so named types based on
+primitives (`string`, `int64`, etc.) work with `Scan` out of the box.
+
+```go
+// Good - scan directly into named type fields
+var e Entry
+rows.Scan(&e.EntryID, &e.TxID, &e.AccountID, &e.Asset, &e.Amount, &e.CreatedAt)
+
+// Bad - unnecessary intermediate variables
+var acctID, assetStr string
+rows.Scan(&e.EntryID, &e.TxID, &acctID, &assetStr, &e.Amount, &e.CreatedAt)
+e.AccountID = AccountID(acctID)
+e.Asset = Asset(assetStr)
+```
+
 ### Connection Management
 
 - Use connection pooling
@@ -334,6 +353,7 @@ func PostTransaction(ctx context.Context, tx *Transaction) error {
 ## Security
 
 - Never log sensitive data (passwords, tokens, full PII)
+- Never expose sensitive data, API keys, passwords, private keys or anything similar. 
 - Validate all inputs
 - Use parameterized queries (no SQL injection)
 - Set timeouts on all external calls

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/prometheus/client_golang v1.23.2
 	go.uber.org/zap v1.27.1
 	google.golang.org/grpc v1.78.0
+	google.golang.org/protobuf v1.36.10
 )
 
 require (
@@ -26,5 +27,4 @@ require (
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251029180050-ab9386a59fda // indirect
-	google.golang.org/protobuf v1.36.10 // indirect
 )

--- a/internal/ledger/mysql_repository.go
+++ b/internal/ledger/mysql_repository.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
 )
 
 // StatusPosted is the status value for a successfully committed transaction.
@@ -17,13 +19,20 @@ const StatusPosted = "posted"
 
 // MySQLRepository implements Repository using a MySQL database.
 type MySQLRepository struct {
-	db     *sql.DB
-	logger *zap.Logger
+	db      *sql.DB
+	logger  *zap.Logger
+	metrics *observability.Metrics
 }
 
 // NewMySQLRepository creates a new MySQLRepository.
-func NewMySQLRepository(db *sql.DB, logger *zap.Logger) *MySQLRepository {
-	return &MySQLRepository{db: db, logger: logger}
+func NewMySQLRepository(db *sql.DB, logger *zap.Logger, metrics *observability.Metrics) *MySQLRepository {
+	return &MySQLRepository{db: db, logger: logger, metrics: metrics}
+}
+
+// dbErr increments the DB error counter and wraps the error with context.
+func (r *MySQLRepository) dbErr(err error, msg string, args ...any) error {
+	r.metrics.DBErrorTotal.Inc()
+	return fmt.Errorf("%s: %w", fmt.Sprintf(msg, args...), err)
 }
 
 // PostTransaction atomically records a double-entry transaction. If a
@@ -36,16 +45,21 @@ func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (
 
 	dbTx, err := r.db.BeginTx(ctx, nil)
 	if err != nil {
-		return nil, fmt.Errorf("beginning transaction: %w", err)
+		return nil, r.dbErr(err, "beginning transaction")
 	}
 	defer dbTx.Rollback() //nolint:errcheck // Rollback after commit returns ErrTxDone which is expected
 
 	// Idempotency check: return existing result if already posted.
 	existing, err := r.findByIdempotencyKey(ctx, dbTx, tx.IdempotencyKey)
 	if err != nil {
-		return nil, fmt.Errorf("checking idempotency: %w", err)
+		return nil, r.dbErr(err, "checking idempotency")
 	}
 	if existing != nil {
+		r.metrics.IdempotencyReplay.Inc()
+		r.logger.Info("idempotency replay",
+			zap.String("tx_id", existing.ID),
+			zap.String("idempotency_key", existing.IdempotencyKey),
+		)
 		return existing, nil
 	}
 
@@ -88,11 +102,11 @@ func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (
 				`INSERT INTO ledger_balances (account_id, asset, balance) VALUES (?, ?, 0)`,
 				pair.accountID, pair.asset,
 			); execErr != nil {
-				return nil, fmt.Errorf("inserting balance row %s/%s: %w", pair.accountID, pair.asset, execErr)
+				return nil, r.dbErr(execErr, "inserting balance row %s/%s", pair.accountID, pair.asset)
 			}
 			balance = 0
 		} else if err != nil {
-			return nil, fmt.Errorf("locking balance %s/%s: %w", pair.accountID, pair.asset, err)
+			return nil, r.dbErr(err, "locking balance %s/%s", pair.accountID, pair.asset)
 		}
 
 		balances[AccountID(pair.accountID)] = Amount(balance)
@@ -115,7 +129,7 @@ func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (
 		 VALUES (?, ?, '', ?, ?)`,
 		tx.ID, tx.IdempotencyKey, StatusPosted, tx.CreatedAt,
 	); err != nil {
-		return nil, fmt.Errorf("inserting transaction: %w", err)
+		return nil, r.dbErr(err, "inserting transaction")
 	}
 
 	// Insert entry rows (one per posting).
@@ -125,7 +139,7 @@ func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (
 			 VALUES (?, ?, ?, ?, ?)`,
 			tx.ID, string(p.AccountID), int64(p.Amount), string(p.Asset), tx.CreatedAt,
 		); err != nil {
-			return nil, fmt.Errorf("inserting entry for %s: %w", p.AccountID, err)
+			return nil, r.dbErr(err, "inserting entry for %s", p.AccountID)
 		}
 	}
 
@@ -140,13 +154,15 @@ func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (
 			`UPDATE ledger_balances SET balance = balance + ? WHERE account_id = ? AND asset = ?`,
 			deltas[pair], pair.accountID, pair.asset,
 		); err != nil {
-			return nil, fmt.Errorf("updating balance for %s/%s: %w", pair.accountID, pair.asset, err)
+			return nil, r.dbErr(err, "updating balance for %s/%s", pair.accountID, pair.asset)
 		}
 	}
 
 	if err := dbTx.Commit(); err != nil {
-		return nil, fmt.Errorf("committing transaction: %w", err)
+		return nil, r.dbErr(err, "committing transaction")
 	}
+
+	r.metrics.TxPostedTotal.Inc()
 
 	r.logger.Info("transaction posted",
 		zap.String("tx_id", tx.ID),
@@ -169,7 +185,7 @@ func (r *MySQLRepository) GetTransaction(ctx context.Context, idempotencyKey str
 		return nil, ErrNotFound
 	}
 	if err != nil {
-		return nil, fmt.Errorf("querying transaction: %w", err)
+		return nil, r.dbErr(err, "querying transaction")
 	}
 
 	postings, err := r.loadPostings(ctx, r.db, tx.ID)
@@ -193,7 +209,7 @@ func (r *MySQLRepository) GetBalance(ctx context.Context, accountID AccountID, a
 		return 0, nil
 	}
 	if err != nil {
-		return 0, fmt.Errorf("querying balance for %s/%s: %w", accountID, asset, err)
+		return 0, r.dbErr(err, "querying balance for %s/%s", accountID, asset)
 	}
 	return Amount(balance), nil
 }
@@ -211,23 +227,20 @@ func (r *MySQLRepository) ListEntries(ctx context.Context, accountID AccountID, 
 		string(accountID), string(asset), cursor, limit,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("querying entries for %s/%s: %w", accountID, asset, err)
+		return nil, r.dbErr(err, "querying entries for %s/%s", accountID, asset)
 	}
 	defer rows.Close() //nolint:errcheck // rows.Err() is checked after iteration
 
 	var entries []Entry
 	for rows.Next() {
 		var e Entry
-		var acctID, assetStr string
-		if err := rows.Scan(&e.EntryID, &e.TxID, &acctID, &assetStr, &e.Amount, &e.CreatedAt); err != nil {
-			return nil, fmt.Errorf("scanning entry: %w", err)
+		if err := rows.Scan(&e.EntryID, &e.TxID, &e.AccountID, &e.Asset, &e.Amount, &e.CreatedAt); err != nil {
+			return nil, r.dbErr(err, "scanning entry")
 		}
-		e.AccountID = AccountID(acctID)
-		e.Asset = Asset(assetStr)
 		entries = append(entries, e)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating entries: %w", err)
+		return nil, r.dbErr(err, "iterating entries")
 	}
 
 	return entries, nil
@@ -246,7 +259,7 @@ func (r *MySQLRepository) findByIdempotencyKey(ctx context.Context, dbTx *sql.Tx
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("querying transaction by idempotency key: %w", err)
+		return nil, r.dbErr(err, "querying transaction by idempotency key")
 	}
 
 	postings, err := r.loadPostings(ctx, dbTx, tx.ID)
@@ -270,28 +283,20 @@ func (r *MySQLRepository) loadPostings(ctx context.Context, q queryable, txID st
 		 FROM ledger_entries WHERE tx_id = ? ORDER BY entry_id`, txID,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("querying entries for tx %s: %w", txID, err)
+		return nil, r.dbErr(err, "querying entries for tx %s", txID)
 	}
 	defer rows.Close() //nolint:errcheck // rows.Err() is checked after iteration
 
 	var postings []Posting
 	for rows.Next() {
-		var (
-			accountID string
-			amount    int64
-			asset     string
-		)
-		if err := rows.Scan(&accountID, &amount, &asset); err != nil {
-			return nil, fmt.Errorf("scanning entry: %w", err)
+		var p Posting
+		if err := rows.Scan(&p.AccountID, &p.Amount, &p.Asset); err != nil {
+			return nil, r.dbErr(err, "scanning entry")
 		}
-		postings = append(postings, Posting{
-			AccountID: AccountID(accountID),
-			Amount:    Amount(amount),
-			Asset:     Asset(asset),
-		})
+		postings = append(postings, p)
 	}
 	if err := rows.Err(); err != nil {
-		return nil, fmt.Errorf("iterating entries: %w", err)
+		return nil, r.dbErr(err, "iterating entries")
 	}
 
 	return postings, nil

--- a/internal/ledger/mysql_repository_integration_test.go
+++ b/internal/ledger/mysql_repository_integration_test.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/CLAM101/exchange-ledger-platform/internal/ledger"
+	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
 	migrations "github.com/CLAM101/exchange-ledger-platform/migrations"
 )
 
@@ -111,7 +112,7 @@ func seedBalance(t *testing.T, accountID ledger.AccountID, asset ledger.Asset, a
 
 func newRepo(t *testing.T) *ledger.MySQLRepository {
 	t.Helper()
-	return ledger.NewMySQLRepository(testDB, zap.NewNop())
+	return ledger.NewMySQLRepository(testDB, zap.NewNop(), observability.NewTestMetrics())
 }
 
 // --- Test: Successful transaction posting ---

--- a/internal/ledger/server.go
+++ b/internal/ledger/server.go
@@ -57,6 +57,10 @@ func (s *Server) PostTransaction(ctx context.Context, req *ledgerv1.PostTransact
 
 	result, err := s.repo.PostTransaction(ctx, tx)
 	if err != nil {
+		s.logger.Warn("PostTransaction failed",
+			zap.String("idempotency_key", req.IdempotencyKey),
+			zap.Error(err),
+		)
 		return nil, domainToStatus(err)
 	}
 

--- a/internal/platform/grpc/health.go
+++ b/internal/platform/grpc/health.go
@@ -1,0 +1,56 @@
+package grpc
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// HealthChecker reports whether a dependency is healthy.
+type HealthChecker interface {
+	Check(ctx context.Context) error
+}
+
+// DBHealthChecker verifies database connectivity via sql.DB.PingContext.
+type DBHealthChecker struct {
+	db *sql.DB
+}
+
+// NewDBHealthChecker creates a new DBHealthChecker.
+func NewDBHealthChecker(db *sql.DB) *DBHealthChecker {
+	return &DBHealthChecker{db: db}
+}
+
+// Check pings the database to verify connectivity.
+func (c *DBHealthChecker) Check(ctx context.Context) error {
+	return c.db.PingContext(ctx)
+}
+
+// WatchHealth periodically checks the given HealthChecker and updates the
+// gRPC health server status. It blocks until ctx is cancelled.
+func WatchHealth(ctx context.Context, hs *health.Server, serviceName string, checker HealthChecker, interval time.Duration, logger *zap.Logger) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			checkCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			err := checker.Check(checkCtx)
+			cancel()
+
+			if err != nil {
+				logger.Warn("health check failed", zap.Error(err))
+				hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
+			} else {
+				hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
+			}
+		}
+	}
+}

--- a/internal/platform/grpc/health_test.go
+++ b/internal/platform/grpc/health_test.go
@@ -1,0 +1,117 @@
+package grpc_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
+	"go.uber.org/zap"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// mockChecker is a test double for HealthChecker.
+type mockChecker struct {
+	mu  sync.Mutex
+	err error
+}
+
+func (m *mockChecker) Check(_ context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.err
+}
+
+func (m *mockChecker) setErr(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.err = err
+}
+
+func TestWatchHealth_SetsServing(t *testing.T) {
+	t.Parallel()
+
+	hs := health.NewServer()
+	checker := &mockChecker{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go platformgrpc.WatchHealth(ctx, hs, "test", checker, 10*time.Millisecond, zap.NewNop())
+
+	// Wait for at least one tick.
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("status = %v, want SERVING", resp.Status)
+	}
+}
+
+func TestWatchHealth_TransitionsToNotServing(t *testing.T) {
+	t.Parallel()
+
+	hs := health.NewServer()
+	checker := &mockChecker{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go platformgrpc.WatchHealth(ctx, hs, "test", checker, 10*time.Millisecond, zap.NewNop())
+
+	// Let it become healthy first.
+	time.Sleep(50 * time.Millisecond)
+
+	// Make it fail.
+	checker.setErr(errors.New("db gone"))
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("status = %v, want NOT_SERVING", resp.Status)
+	}
+}
+
+func TestWatchHealth_RecoversAfterFailure(t *testing.T) {
+	t.Parallel()
+
+	hs := health.NewServer()
+	checker := &mockChecker{err: errors.New("initial failure")}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go platformgrpc.WatchHealth(ctx, hs, "test", checker, 10*time.Millisecond, zap.NewNop())
+
+	// Wait for NOT_SERVING.
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_NOT_SERVING {
+		t.Errorf("status = %v, want NOT_SERVING", resp.Status)
+	}
+
+	// Recover.
+	checker.setErr(nil)
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err = hs.Check(context.Background(), &healthpb.HealthCheckRequest{Service: "test"})
+	if err != nil {
+		t.Fatalf("Check: %v", err)
+	}
+	if resp.Status != healthpb.HealthCheckResponse_SERVING {
+		t.Errorf("status = %v, want SERVING", resp.Status)
+	}
+}

--- a/internal/platform/grpc/interceptors_test.go
+++ b/internal/platform/grpc/interceptors_test.go
@@ -6,7 +6,6 @@ import (
 
 	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
 	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
@@ -127,26 +126,8 @@ func TestLoggingInterceptor(t *testing.T) {
 	}
 }
 
-// newTestMetrics creates a Metrics instance backed by a custom registry
-// so tests don't collide with the global Prometheus registry.
 func newTestMetrics() *observability.Metrics {
-	reg := prometheus.NewRegistry()
-
-	requestTotal := prometheus.NewCounterVec(
-		prometheus.CounterOpts{Name: "test_requests_total"},
-		[]string{"method", "status"},
-	)
-	requestDuration := prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{Name: "test_request_duration_seconds", Buckets: prometheus.DefBuckets},
-		[]string{"method", "status"},
-	)
-
-	reg.MustRegister(requestTotal, requestDuration)
-
-	return &observability.Metrics{
-		RequestTotal:    requestTotal,
-		RequestDuration: requestDuration,
-	}
+	return observability.NewTestMetrics()
 }
 
 func TestMetricsInterceptor(t *testing.T) {

--- a/internal/platform/grpc/server.go
+++ b/internal/platform/grpc/server.go
@@ -4,12 +4,14 @@ import (
 	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 )
 
 // NewServer creates a gRPC server pre-wired with recovery, logging, and
-// metrics interceptors, and with server reflection enabled.
-func NewServer(logger *zap.Logger, metrics *observability.Metrics) *grpc.Server {
+// metrics interceptors, and with server reflection and health service enabled.
+func NewServer(logger *zap.Logger, metrics *observability.Metrics, hs *health.Server) *grpc.Server {
 	srv := grpc.NewServer(
 		grpc.ChainUnaryInterceptor(
 			RecoveryInterceptor(logger),
@@ -19,6 +21,10 @@ func NewServer(logger *zap.Logger, metrics *observability.Metrics) *grpc.Server 
 	)
 
 	reflection.Register(srv)
+
+	if hs != nil {
+		healthpb.RegisterHealthServer(srv, hs)
+	}
 
 	return srv
 }

--- a/internal/platform/observability/metrics.go
+++ b/internal/platform/observability/metrics.go
@@ -11,6 +11,10 @@ import (
 type Metrics struct {
 	RequestTotal    *prometheus.CounterVec   // Total requests
 	RequestDuration *prometheus.HistogramVec // Request latency
+
+	TxPostedTotal     prometheus.Counter // Committed transactions
+	IdempotencyReplay prometheus.Counter // Idempotency key replays
+	DBErrorTotal      prometheus.Counter // Database errors
 }
 
 // NewMetrics creates metrics for a service
@@ -34,11 +38,32 @@ func NewMetrics(serviceName string) *Metrics {
 		[]string{"method", "status"},
 	)
 
-	prometheus.MustRegister(requestTotal, requestDuration)
+	txPostedTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ledger_tx_posted_total",
+		Help:        "Total number of committed transactions",
+		ConstLabels: prometheus.Labels{"service": serviceName},
+	})
+
+	idempotencyReplay := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ledger_idempotency_replay_total",
+		Help:        "Total number of idempotency key replays",
+		ConstLabels: prometheus.Labels{"service": serviceName},
+	})
+
+	dbErrorTotal := prometheus.NewCounter(prometheus.CounterOpts{
+		Name:        "ledger_db_errors_total",
+		Help:        "Total number of database errors",
+		ConstLabels: prometheus.Labels{"service": serviceName},
+	})
+
+	prometheus.MustRegister(requestTotal, requestDuration, txPostedTotal, idempotencyReplay, dbErrorTotal)
 
 	return &Metrics{
-		RequestTotal:    requestTotal,
-		RequestDuration: requestDuration,
+		RequestTotal:      requestTotal,
+		RequestDuration:   requestDuration,
+		TxPostedTotal:     txPostedTotal,
+		IdempotencyReplay: idempotencyReplay,
+		DBErrorTotal:      dbErrorTotal,
 	}
 }
 

--- a/internal/platform/observability/metrics_test.go
+++ b/internal/platform/observability/metrics_test.go
@@ -22,6 +22,23 @@ func TestNewMetrics(t *testing.T) {
 		t.Error("RequestDuration is nil")
 	}
 
+	if metrics.TxPostedTotal == nil {
+		t.Error("TxPostedTotal is nil")
+	}
+
+	if metrics.IdempotencyReplay == nil {
+		t.Error("IdempotencyReplay is nil")
+	}
+
+	if metrics.DBErrorTotal == nil {
+		t.Error("DBErrorTotal is nil")
+	}
+
+	// Test that domain counters can be incremented (should not panic)
+	metrics.TxPostedTotal.Inc()
+	metrics.IdempotencyReplay.Inc()
+	metrics.DBErrorTotal.Inc()
+
 	// Test that handler works
 	handler := metrics.Handler()
 	if handler == nil {

--- a/internal/platform/observability/testing.go
+++ b/internal/platform/observability/testing.go
@@ -1,0 +1,31 @@
+package observability
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// NewTestMetrics creates a Metrics instance backed by a custom registry
+// so tests don't collide with the global Prometheus registry.
+func NewTestMetrics() *Metrics {
+	reg := prometheus.NewRegistry()
+
+	requestTotal := prometheus.NewCounterVec(
+		prometheus.CounterOpts{Name: "test_requests_total"},
+		[]string{"method", "status"},
+	)
+	requestDuration := prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{Name: "test_request_duration_seconds", Buckets: prometheus.DefBuckets},
+		[]string{"method", "status"},
+	)
+	txPostedTotal := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_ledger_tx_posted_total"})
+	idempotencyReplay := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_ledger_idempotency_replay_total"})
+	dbErrorTotal := prometheus.NewCounter(prometheus.CounterOpts{Name: "test_ledger_db_errors_total"})
+
+	reg.MustRegister(requestTotal, requestDuration, txPostedTotal, idempotencyReplay, dbErrorTotal)
+
+	return &Metrics{
+		RequestTotal:      requestTotal,
+		RequestDuration:   requestDuration,
+		TxPostedTotal:     txPostedTotal,
+		IdempotencyReplay: idempotencyReplay,
+		DBErrorTotal:      dbErrorTotal,
+	}
+}


### PR DESCRIPTION
## Summary
- Register standard gRPC health service (`grpc.health.v1`) with a background DB-ping watcher that flips readiness status on connectivity loss
- Add three Prometheus counters: `ledger_tx_posted_total`, `ledger_idempotency_replay_total`, `ledger_db_errors_total`
- Enrich write-path logging with `tx_id` and `idempotency_key` for traceability
- Extract shared `NewTestMetrics()` helper to eliminate test duplication
- Set NOT_SERVING on graceful shutdown for proper connection draining

## Changes
- `internal/platform/grpc/health.go` — new `HealthChecker` interface, `DBHealthChecker`, `WatchHealth` goroutine
- `internal/platform/grpc/server.go` — `NewServer` accepts optional `*health.Server`, registers health service
- `internal/platform/observability/metrics.go` — three new domain counters on `Metrics` struct
- `internal/platform/observability/testing.go` — shared `NewTestMetrics()` for test isolation
- `internal/ledger/mysql_repository.go` — accepts `*Metrics`, `dbErr` helper, increments counters, logs idempotency replays
- `internal/ledger/server.go` — logs `idempotency_key` on PostTransaction failure
- `cmd/ledger/main.go` — wires health server, DB checker, passes metrics to repo, extracts `serviceName` const

## Test plan
- `make test` — unit tests pass (health watcher transitions, metrics increment, interceptors)
- `make lint` — clean
- Integration tests updated to pass metrics via `NewTestMetrics()`
- Docker: `grpc_health_probe -addr=:9001` should return SERVING when DB is up

Closes #8