### PR TITLE
Add account gRPC API (T2.2)

### DIFF
--- a/cmd/account/main.go
+++ b/cmd/account/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/CLAM101/exchange-ledger-platform/internal/account"
 	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
 	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
 )
 
 const serviceName = "account"
@@ -95,8 +96,7 @@ func run() error {
 	dbChecker := platformgrpc.NewDBHealthChecker(db)
 	go platformgrpc.WatchHealth(ctx, hs, serviceName, dbChecker, 10*time.Second, logger)
 
-	// Repository (will be used by gRPC handler in T2.2).
-	_ = account.NewMySQLRepository(db, logger, metrics)
+	repo := account.NewMySQLRepository(db, logger, metrics)
 
 	port := getEnv("GRPC_PORT", "9002")
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
@@ -106,7 +106,8 @@ func run() error {
 
 	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
 
-	// TODO: Register service implementations (T2.2)
+	handler := account.NewServer(repo, logger)
+	accountv1.RegisterAccountServiceServer(grpcServer, handler)
 
 	logger.Info("Account service listening", zap.String("port", port))
 

--- a/internal/account/domain.go
+++ b/internal/account/domain.go
@@ -26,6 +26,14 @@ type UserAssetAccount struct {
 	CreatedAt       time.Time
 }
 
+// DefaultAsset is the asset automatically linked when a user is created.
+const DefaultAsset = "BTC"
+
+// LedgerAccountID returns the deterministic ledger account ID for a user.
+func LedgerAccountID(id UserID) string {
+	return "user:" + string(id)
+}
+
 // Sentinel errors for the account domain.
 var (
 	ErrNotFound    = errors.New("not found")

--- a/internal/account/domain_test.go
+++ b/internal/account/domain_test.go
@@ -6,6 +6,30 @@ import (
 	"github.com/CLAM101/exchange-ledger-platform/internal/account"
 )
 
+func TestLedgerAccountID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		id   account.UserID
+		want string
+	}{
+		{"standard id", "abc-123", "user:abc-123"},
+		{"uuid", "550e8400-e29b-41d4-a716-446655440000", "user:550e8400-e29b-41d4-a716-446655440000"},
+		{"empty", "", "user:"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := account.LedgerAccountID(tt.id)
+			if got != tt.want {
+				t.Errorf("LedgerAccountID(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestUserValidate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/account/grpc_test.go
+++ b/internal/account/grpc_test.go
@@ -1,0 +1,189 @@
+package account_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/account"
+	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+
+	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
+)
+
+const bufSize = 1024 * 1024
+
+// setupGRPC creates an in-memory gRPC server+client pair with the given mock repo.
+func setupGRPC(t *testing.T, repo account.Repository) accountv1.AccountServiceClient {
+	t.Helper()
+
+	logger := zap.NewNop()
+	metrics := observability.NewTestMetrics()
+	hs := health.NewServer()
+	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+
+	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
+	handler := account.NewServer(repo, logger)
+	accountv1.RegisterAccountServiceServer(grpcServer, handler)
+
+	lis := bufconn.Listen(bufSize)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Logf("gRPC server exited: %v", err)
+		}
+	}()
+	t.Cleanup(func() { grpcServer.Stop() })
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return accountv1.NewAccountServiceClient(conn)
+}
+
+func TestGRPC_CreateUser_Success(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	repo := &mockRepo{
+		createUserFn: func(_ context.Context, u account.User) (*account.User, error) {
+			return &account.User{
+				ID:             "user-grpc-1",
+				Email:          u.Email,
+				IdempotencyKey: u.IdempotencyKey,
+				CreatedAt:      now,
+			}, nil
+		},
+		linkAssetFn: func(_ context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
+			return &ua, nil
+		},
+	}
+
+	client := setupGRPC(t, repo)
+
+	resp, err := client.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email:          "grpc@example.com",
+		IdempotencyKey: "grpc-key-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if resp.User.Id != "user-grpc-1" {
+		t.Errorf("id = %q, want %q", resp.User.Id, "user-grpc-1")
+	}
+	if resp.User.Email != "grpc@example.com" {
+		t.Errorf("email = %q, want %q", resp.User.Email, "grpc@example.com")
+	}
+}
+
+func TestGRPC_GetUser_Success(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	repo := &mockRepo{
+		getUserFn: func(_ context.Context, id account.UserID) (*account.User, error) {
+			return &account.User{
+				ID:        id,
+				Email:     "grpc@example.com",
+				CreatedAt: now,
+			}, nil
+		},
+	}
+
+	client := setupGRPC(t, repo)
+
+	resp, err := client.GetUser(context.Background(), &accountv1.GetUserRequest{
+		UserId: "user-grpc-2",
+	})
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if resp.User.Id != "user-grpc-2" {
+		t.Errorf("id = %q, want %q", resp.User.Id, "user-grpc-2")
+	}
+}
+
+func TestGRPC_GetLedgerAccount_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockRepo{
+		getLedgerAccountFn: func(_ context.Context, _ account.UserID, _ string) (string, error) {
+			return "user:user-grpc-3", nil
+		},
+	}
+
+	client := setupGRPC(t, repo)
+
+	resp, err := client.GetLedgerAccount(context.Background(), &accountv1.GetLedgerAccountRequest{
+		UserId: "user-grpc-3",
+		Asset:  "BTC",
+	})
+	if err != nil {
+		t.Fatalf("GetLedgerAccount: %v", err)
+	}
+	if resp.LedgerAccountId != "user:user-grpc-3" {
+		t.Errorf("ledger_account_id = %q, want %q", resp.LedgerAccountId, "user:user-grpc-3")
+	}
+}
+
+func TestGRPC_CreateUser_InvalidEmail(t *testing.T) {
+	t.Parallel()
+
+	client := setupGRPC(t, &mockRepo{})
+
+	_, err := client.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email:          "bad-email",
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestGRPC_GetUser_NotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockRepo{
+		getUserFn: func(_ context.Context, _ account.UserID) (*account.User, error) {
+			return nil, account.ErrNotFound
+		},
+	}
+
+	client := setupGRPC(t, repo)
+
+	_, err := client.GetUser(context.Background(), &accountv1.GetUserRequest{
+		UserId: "nonexistent",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}

--- a/internal/account/mysql_repository_integration_test.go
+++ b/internal/account/mysql_repository_integration_test.go
@@ -103,7 +103,7 @@ func newRepo(t *testing.T) *account.MySQLRepository {
 
 // --- Test: CreateUser success ---
 
-func TestCreateUser_Success(t *testing.T) {
+func TestCreateUser_Repo_Success(t *testing.T) {
 	truncateTables(t)
 	repo := newRepo(t)
 
@@ -171,7 +171,7 @@ func TestCreateUser_IdempotencyReplay(t *testing.T) {
 
 // --- Test: CreateUser duplicate email ---
 
-func TestCreateUser_DuplicateEmail(t *testing.T) {
+func TestCreateUser_Repo_DuplicateEmail(t *testing.T) {
 	truncateTables(t)
 	repo := newRepo(t)
 
@@ -221,7 +221,7 @@ func TestGetUser_Found(t *testing.T) {
 
 // --- Test: GetUser not found ---
 
-func TestGetUser_NotFound(t *testing.T) {
+func TestGetUser_Repo_NotFound(t *testing.T) {
 	truncateTables(t)
 	repo := newRepo(t)
 

--- a/internal/account/server.go
+++ b/internal/account/server.go
@@ -1,0 +1,119 @@
+package account
+
+import (
+	"context"
+	"errors"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+)
+
+// Server implements the AccountService gRPC interface.
+type Server struct {
+	accountv1.UnimplementedAccountServiceServer
+	repo   Repository
+	logger *zap.Logger
+}
+
+// NewServer creates a new AccountService gRPC server.
+func NewServer(repo Repository, logger *zap.Logger) *Server {
+	return &Server{repo: repo, logger: logger}
+}
+
+// CreateUser registers a new user and auto-links the default BTC ledger account.
+func (s *Server) CreateUser(ctx context.Context, req *accountv1.CreateUserRequest) (*accountv1.CreateUserResponse, error) {
+	u := User{
+		Email:          req.Email,
+		IdempotencyKey: req.IdempotencyKey,
+	}
+	if err := u.Validate(); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	user, err := s.repo.CreateUser(ctx, u)
+	if err != nil {
+		s.logger.Warn("CreateUser failed",
+			zap.String("idempotency_key", req.IdempotencyKey),
+			zap.Error(err),
+		)
+		return nil, domainToStatus(err)
+	}
+
+	// Auto-link the default asset account.
+	if _, err := s.repo.LinkAssetAccount(ctx, UserAssetAccount{
+		UserID:          user.ID,
+		Asset:           DefaultAsset,
+		LedgerAccountID: LedgerAccountID(user.ID),
+	}); err != nil {
+		s.logger.Error("LinkAssetAccount failed after user creation",
+			zap.String("user_id", string(user.ID)),
+			zap.Error(err),
+		)
+		return nil, status.Error(codes.Internal, "failed to link asset account")
+	}
+
+	return &accountv1.CreateUserResponse{
+		User: userToProto(user),
+	}, nil
+}
+
+// GetUser retrieves a user by ID.
+func (s *Server) GetUser(ctx context.Context, req *accountv1.GetUserRequest) (*accountv1.GetUserResponse, error) {
+	if req.UserId == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+
+	user, err := s.repo.GetUser(ctx, UserID(req.UserId))
+	if err != nil {
+		return nil, domainToStatus(err)
+	}
+
+	return &accountv1.GetUserResponse{
+		User: userToProto(user),
+	}, nil
+}
+
+// GetLedgerAccount returns the ledger account ID for a user and asset pair.
+func (s *Server) GetLedgerAccount(ctx context.Context, req *accountv1.GetLedgerAccountRequest) (*accountv1.GetLedgerAccountResponse, error) {
+	if req.UserId == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+	if req.Asset == "" {
+		return nil, status.Error(codes.InvalidArgument, "asset is required")
+	}
+
+	ledgerID, err := s.repo.GetLedgerAccountID(ctx, UserID(req.UserId), req.Asset)
+	if err != nil {
+		return nil, domainToStatus(err)
+	}
+
+	return &accountv1.GetLedgerAccountResponse{
+		UserId:          req.UserId,
+		Asset:           req.Asset,
+		LedgerAccountId: ledgerID,
+	}, nil
+}
+
+// domainToStatus maps domain errors to gRPC status codes.
+func domainToStatus(err error) error {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	case errors.Is(err, ErrEmailExists):
+		return status.Error(codes.AlreadyExists, err.Error())
+	default:
+		return status.Error(codes.Internal, "internal error")
+	}
+}
+
+func userToProto(u *User) *accountv1.User {
+	return &accountv1.User{
+		Id:        string(u.ID),
+		Email:     u.Email,
+		CreatedAt: timestamppb.New(u.CreatedAt),
+	}
+}

--- a/internal/account/server_test.go
+++ b/internal/account/server_test.go
@@ -1,0 +1,352 @@
+package account_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/account"
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+)
+
+// mockRepo is a test double for account.Repository.
+type mockRepo struct {
+	createUserFn       func(ctx context.Context, user account.User) (*account.User, error)
+	getUserFn          func(ctx context.Context, id account.UserID) (*account.User, error)
+	getUserByEmailFn   func(ctx context.Context, email string) (*account.User, error)
+	linkAssetFn        func(ctx context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error)
+	getLedgerAccountFn func(ctx context.Context, userID account.UserID, asset string) (string, error)
+}
+
+func (m *mockRepo) CreateUser(ctx context.Context, user account.User) (*account.User, error) {
+	return m.createUserFn(ctx, user)
+}
+
+func (m *mockRepo) GetUser(ctx context.Context, id account.UserID) (*account.User, error) {
+	return m.getUserFn(ctx, id)
+}
+
+func (m *mockRepo) GetUserByEmail(ctx context.Context, email string) (*account.User, error) {
+	return m.getUserByEmailFn(ctx, email)
+}
+
+func (m *mockRepo) LinkAssetAccount(ctx context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
+	return m.linkAssetFn(ctx, ua)
+}
+
+func (m *mockRepo) GetLedgerAccountID(ctx context.Context, userID account.UserID, asset string) (string, error) {
+	return m.getLedgerAccountFn(ctx, userID, asset)
+}
+
+func newTestServer(repo account.Repository) *account.Server {
+	return account.NewServer(repo, zap.NewNop())
+}
+
+// --- CreateUser tests ---
+
+func TestCreateUser_MissingEmail(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestCreateUser_InvalidEmail(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email:          "alice.example.com",
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestCreateUser_MissingIdempotencyKey(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email: "alice@example.com",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestCreateUser_Success(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	var linkCalled bool
+	var linkedAsset string
+	var linkedLedgerID string
+
+	repo := &mockRepo{
+		createUserFn: func(_ context.Context, u account.User) (*account.User, error) {
+			return &account.User{
+				ID:             "user-abc",
+				Email:          u.Email,
+				IdempotencyKey: u.IdempotencyKey,
+				CreatedAt:      now,
+			}, nil
+		},
+		linkAssetFn: func(_ context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
+			linkCalled = true
+			linkedAsset = ua.Asset
+			linkedLedgerID = ua.LedgerAccountID
+			return &ua, nil
+		},
+	}
+	srv := newTestServer(repo)
+
+	resp, err := srv.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email:          "alice@example.com",
+		IdempotencyKey: "key-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	if resp.User.Id != "user-abc" {
+		t.Errorf("id = %q, want %q", resp.User.Id, "user-abc")
+	}
+	if resp.User.Email != "alice@example.com" {
+		t.Errorf("email = %q, want %q", resp.User.Email, "alice@example.com")
+	}
+	if !linkCalled {
+		t.Error("LinkAssetAccount was not called")
+	}
+	if linkedAsset != account.DefaultAsset {
+		t.Errorf("linked asset = %q, want %q", linkedAsset, account.DefaultAsset)
+	}
+	if linkedLedgerID != "user:user-abc" {
+		t.Errorf("linked ledger ID = %q, want %q", linkedLedgerID, "user:user-abc")
+	}
+}
+
+func TestCreateUser_DuplicateEmail(t *testing.T) {
+	t.Parallel()
+	repo := &mockRepo{
+		createUserFn: func(_ context.Context, _ account.User) (*account.User, error) {
+			return nil, account.ErrEmailExists
+		},
+	}
+	srv := newTestServer(repo)
+
+	_, err := srv.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email:          "alice@example.com",
+		IdempotencyKey: "key-dup",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.AlreadyExists {
+		t.Errorf("code = %v, want AlreadyExists", st.Code())
+	}
+}
+
+func TestCreateUser_RepoError(t *testing.T) {
+	t.Parallel()
+	repo := &mockRepo{
+		createUserFn: func(_ context.Context, _ account.User) (*account.User, error) {
+			return nil, errors.New("db connection lost")
+		},
+	}
+	srv := newTestServer(repo)
+
+	_, err := srv.CreateUser(context.Background(), &accountv1.CreateUserRequest{
+		Email:          "alice@example.com",
+		IdempotencyKey: "key-err",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("code = %v, want Internal", st.Code())
+	}
+}
+
+// --- GetUser tests ---
+
+func TestGetUser_MissingUserID(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.GetUser(context.Background(), &accountv1.GetUserRequest{})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestGetUser_Success(t *testing.T) {
+	t.Parallel()
+	now := time.Now()
+
+	repo := &mockRepo{
+		getUserFn: func(_ context.Context, id account.UserID) (*account.User, error) {
+			return &account.User{
+				ID:        id,
+				Email:     "alice@example.com",
+				CreatedAt: now,
+			}, nil
+		},
+	}
+	srv := newTestServer(repo)
+
+	resp, err := srv.GetUser(context.Background(), &accountv1.GetUserRequest{
+		UserId: "user-abc",
+	})
+	if err != nil {
+		t.Fatalf("GetUser: %v", err)
+	}
+	if resp.User.Id != "user-abc" {
+		t.Errorf("id = %q, want %q", resp.User.Id, "user-abc")
+	}
+	if resp.User.Email != "alice@example.com" {
+		t.Errorf("email = %q, want %q", resp.User.Email, "alice@example.com")
+	}
+}
+
+func TestGetUser_NotFound(t *testing.T) {
+	t.Parallel()
+	repo := &mockRepo{
+		getUserFn: func(_ context.Context, _ account.UserID) (*account.User, error) {
+			return nil, account.ErrNotFound
+		},
+	}
+	srv := newTestServer(repo)
+
+	_, err := srv.GetUser(context.Background(), &accountv1.GetUserRequest{
+		UserId: "nonexistent",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+// --- GetLedgerAccount tests ---
+
+func TestGetLedgerAccount_MissingUserID(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.GetLedgerAccount(context.Background(), &accountv1.GetLedgerAccountRequest{
+		Asset: "BTC",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestGetLedgerAccount_MissingAsset(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.GetLedgerAccount(context.Background(), &accountv1.GetLedgerAccountRequest{
+		UserId: "user-abc",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestGetLedgerAccount_Success(t *testing.T) {
+	t.Parallel()
+	repo := &mockRepo{
+		getLedgerAccountFn: func(_ context.Context, _ account.UserID, _ string) (string, error) {
+			return "user:user-abc", nil
+		},
+	}
+	srv := newTestServer(repo)
+
+	resp, err := srv.GetLedgerAccount(context.Background(), &accountv1.GetLedgerAccountRequest{
+		UserId: "user-abc",
+		Asset:  "BTC",
+	})
+	if err != nil {
+		t.Fatalf("GetLedgerAccount: %v", err)
+	}
+	if resp.UserId != "user-abc" {
+		t.Errorf("user_id = %q, want %q", resp.UserId, "user-abc")
+	}
+	if resp.Asset != "BTC" {
+		t.Errorf("asset = %q, want %q", resp.Asset, "BTC")
+	}
+	if resp.LedgerAccountId != "user:user-abc" {
+		t.Errorf("ledger_account_id = %q, want %q", resp.LedgerAccountId, "user:user-abc")
+	}
+}
+
+func TestGetLedgerAccount_NotFound(t *testing.T) {
+	t.Parallel()
+	repo := &mockRepo{
+		getLedgerAccountFn: func(_ context.Context, _ account.UserID, _ string) (string, error) {
+			return "", account.ErrNotFound
+		},
+	}
+	srv := newTestServer(repo)
+
+	_, err := srv.GetLedgerAccount(context.Background(), &accountv1.GetLedgerAccountRequest{
+		UserId: "nonexistent",
+		Asset:  "BTC",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}

--- a/proto/account/v1/account.proto
+++ b/proto/account/v1/account.proto
@@ -1,0 +1,53 @@
+syntax = "proto3";
+
+package account.v1;
+
+option go_package = "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1;accountv1";
+
+import "google/protobuf/timestamp.proto";
+
+service AccountService {
+  // CreateUser registers a new user and auto-links a BTC ledger account.
+  // Idempotent: replaying the same idempotency_key returns the existing result.
+  rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
+
+  // GetUser retrieves a user by ID.
+  rpc GetUser(GetUserRequest) returns (GetUserResponse);
+
+  // GetLedgerAccount returns the ledger account ID for a user and asset pair.
+  rpc GetLedgerAccount(GetLedgerAccountRequest) returns (GetLedgerAccountResponse);
+}
+
+message User {
+  string id = 1;
+  string email = 2;
+  google.protobuf.Timestamp created_at = 3;
+}
+
+message CreateUserRequest {
+  string email = 1;
+  string idempotency_key = 2;
+}
+
+message CreateUserResponse {
+  User user = 1;
+}
+
+message GetUserRequest {
+  string user_id = 1;
+}
+
+message GetUserResponse {
+  User user = 1;
+}
+
+message GetLedgerAccountRequest {
+  string user_id = 1;
+  string asset = 2;
+}
+
+message GetLedgerAccountResponse {
+  string user_id = 1;
+  string asset = 2;
+  string ledger_account_id = 3;
+}


### PR DESCRIPTION
## Summary
- Add protobuf definition for `AccountService` with 3 RPCs: `CreateUser`, `GetUser`, `GetLedgerAccount`
- Implement gRPC server with validation, domain error mapping, and auto-linking of BTC ledger account on user creation
- Add 15 unit tests (mock repo) and 5 bufconn gRPC integration tests (full transport stack)
- Wire handler into `cmd/account/main.go`

## Changes
| File | Action |
|------|--------|
| `proto/account/v1/account.proto` | New — protobuf service definition |
| `internal/account/domain.go` | Add `DefaultAsset`, `LedgerAccountID()` |
| `internal/account/server.go` | New — gRPC handler implementation |
| `internal/account/server_test.go` | New — 15 unit tests with mock repo |
| `internal/account/grpc_test.go` | New — 5 bufconn integration tests |
| `internal/account/domain_test.go` | Add `TestLedgerAccountID` |
| `cmd/account/main.go` | Wire handler + register service |

## Test plan
- [x] `go build ./...` compiles
- [x] `golangci-lint run ./...` passes
- [x] `go test ./internal/account/...` — 19 tests pass
- [x] `go test ./...` — 44 tests pass across all packages

Closes #10