### PR TITLE
Add wallet deposit workflow with ledger overdraft fix (T3.1)

### DIFF
--- a/cmd/wallet/main.go
+++ b/cmd/wallet/main.go
@@ -2,8 +2,140 @@
 // The wallet service handles deposit and withdrawal orchestration.
 package main
 
-import "log"
+import (
+	"context"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+
+	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
+	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
+	"github.com/CLAM101/exchange-ledger-platform/internal/wallet"
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
+	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
+)
+
+const serviceName = "wallet"
 
 func main() {
-	log.Println("Wallet service - TODO: implement")
+	if err := run(); err != nil {
+		log.Fatalf("failed to run wallet service: %v", err)
+	}
+}
+
+func run() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	logger, err := observability.NewLogger(serviceName)
+	if err != nil {
+		return fmt.Errorf("failed to create logger: %w", err)
+	}
+	defer func() {
+		_ = logger.Sync() //nolint:errcheck // Sync errors are acceptable in defer
+	}()
+
+	metrics := observability.NewMetrics(serviceName)
+
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", metrics.Handler())
+		metricsPort := getEnv("METRICS_PORT", "9093")
+		server := &http.Server{
+			Addr:              ":" + metricsPort,
+			Handler:           mux,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		logger.Info("metrics endpoint starting", zap.String("port", metricsPort))
+		if serveErr := server.ListenAndServe(); serveErr != nil {
+			logger.Error("metrics server failed", zap.Error(serveErr))
+		}
+	}()
+
+	// Handle graceful shutdown.
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+
+	go func() {
+		<-sigChan
+		logger.Info("shutting down wallet service...")
+		cancel()
+	}()
+
+	// Connect to Account service.
+	accountAddr := getEnv("ACCOUNT_ADDR", "localhost:9002")
+	accountConn, err := grpc.NewClient(accountAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connecting to account service: %w", err)
+	}
+	defer accountConn.Close() //nolint:errcheck // Best-effort close on shutdown
+	logger.Info("connected to account service", zap.String("addr", accountAddr))
+
+	// Connect to Ledger service.
+	ledgerAddr := getEnv("LEDGER_ADDR", "localhost:9001")
+	ledgerConn, err := grpc.NewClient(ledgerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		return fmt.Errorf("connecting to ledger service: %w", err)
+	}
+	defer ledgerConn.Close() //nolint:errcheck // Best-effort close on shutdown
+	logger.Info("connected to ledger service", zap.String("addr", ledgerAddr))
+
+	// Health service (no DB checker — wallet is stateless).
+	hs := health.NewServer()
+	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+	hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
+
+	port := getEnv("GRPC_PORT", "9003")
+	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
+	if err != nil {
+		return fmt.Errorf("failed to listen: %w", err)
+	}
+
+	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
+
+	accountClient := accountv1.NewAccountServiceClient(accountConn)
+	ledgerClient := ledgerv1.NewLedgerServiceClient(ledgerConn)
+	handler := wallet.NewServer(accountClient, ledgerClient, logger)
+	walletv1.RegisterWalletServiceServer(grpcServer, handler)
+
+	logger.Info("Wallet service listening", zap.String("port", port))
+
+	// Start gRPC server.
+	errChan := make(chan error, 1)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			errChan <- fmt.Errorf("failed to serve: %w", err)
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		logger.Info("context cancelled, shutting down")
+		hs.SetServingStatus("", healthpb.HealthCheckResponse_NOT_SERVING)
+		hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
+		grpcServer.GracefulStop()
+		return nil
+	case err := <-errChan:
+		logger.Error("failed to serve", zap.Error(err))
+		return err
+	}
+}
+
+func getEnv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
 }

--- a/internal/ledger/domain.go
+++ b/internal/ledger/domain.go
@@ -2,10 +2,24 @@
 // and overdraft prevention for the exchange ledger platform.
 package ledger
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // AccountID uniquely identifies a ledger account.
+// System accounts use known prefixes ("external:", "fees:", "pool:").
+// User accounts use the "user:" prefix.
 type AccountID string
+
+// OverdraftExempt returns true for accounts that are allowed to go negative.
+// Only "external:" accounts qualify — these are bookkeeping counterparties
+// (e.g. "external:deposits") that offset real user balances, not actual
+// asset holdings. All other accounts (user, fees, pool, unknown) are
+// protected by overdraft checks.
+func (id AccountID) OverdraftExempt() bool {
+	return strings.HasPrefix(string(id), "external:")
+}
 
 // Asset identifies the currency being transacted (e.g. "BTC").
 type Asset string

--- a/internal/ledger/mysql_repository.go
+++ b/internal/ledger/mysql_repository.go
@@ -112,10 +112,15 @@ func (r *MySQLRepository) PostTransaction(ctx context.Context, tx Transaction) (
 		balances[AccountID(pair.accountID)] = Amount(balance)
 	}
 
-	// Check overdraft using the domain logic. The balances map is keyed by
-	// AccountID alone, which is safe because Validate() enforces that all
-	// postings share the same asset (ErrAssetMismatch).
-	if err := tx.CheckOverdraft(balances); err != nil {
+	// Check overdraft for all accounts except external counterparties
+	// (e.g. "external:deposits"), which go negative by design.
+	checkedBalances := make(map[AccountID]Amount, len(balances))
+	for acctID, bal := range balances {
+		if !acctID.OverdraftExempt() {
+			checkedBalances[acctID] = bal
+		}
+	}
+	if err := tx.CheckOverdraft(checkedBalances); err != nil {
 		return nil, err
 	}
 

--- a/internal/wallet/grpc_test.go
+++ b/internal/wallet/grpc_test.go
@@ -1,0 +1,139 @@
+package wallet_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
+	"github.com/CLAM101/exchange-ledger-platform/internal/wallet"
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
+	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
+
+	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
+)
+
+const bufSize = 1024 * 1024
+
+// setupGRPC creates an in-memory gRPC server+client pair for the wallet service.
+func setupGRPC(t *testing.T, ac accountv1.AccountServiceClient, lc ledgerv1.LedgerServiceClient) walletv1.WalletServiceClient {
+	t.Helper()
+
+	logger := zap.NewNop()
+	metrics := observability.NewTestMetrics()
+	hs := health.NewServer()
+	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+
+	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
+	handler := wallet.NewServer(ac, lc, logger)
+	walletv1.RegisterWalletServiceServer(grpcServer, handler)
+
+	lis := bufconn.Listen(bufSize)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Logf("gRPC server exited: %v", err)
+		}
+	}()
+	t.Cleanup(func() { grpcServer.Stop() })
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return walletv1.NewWalletServiceClient(conn)
+}
+
+func TestGRPC_Deposit_Success(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return &accountv1.GetLedgerAccountResponse{LedgerAccountId: "user:user-1"}, nil
+		},
+	}
+	lc := &mockLedgerClient{
+		postTransactionFn: func(_ context.Context, _ *ledgerv1.PostTransactionRequest, _ ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+			return &ledgerv1.PostTransactionResponse{
+				Transaction: &ledgerv1.Transaction{Id: "tx-grpc-1"},
+			}, nil
+		},
+	}
+
+	client := setupGRPC(t, ac, lc)
+
+	resp, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         3000,
+		IdempotencyKey: "grpc-key-1",
+	})
+	if err != nil {
+		t.Fatalf("Deposit: %v", err)
+	}
+	if resp.TransactionId != "tx-grpc-1" {
+		t.Errorf("transaction_id = %q, want %q", resp.TransactionId, "tx-grpc-1")
+	}
+}
+
+func TestGRPC_Deposit_InvalidArgument(t *testing.T) {
+	t.Parallel()
+
+	client := setupGRPC(t, &mockAccountClient{}, &mockLedgerClient{})
+
+	_, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+		// Missing user_id
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestGRPC_Deposit_UserNotFound(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "user not found")
+		},
+	}
+
+	client := setupGRPC(t, ac, &mockLedgerClient{})
+
+	_, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "nonexistent",
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}

--- a/internal/wallet/server.go
+++ b/internal/wallet/server.go
@@ -1,0 +1,101 @@
+// Package wallet implements deposit and withdrawal orchestration
+// using a reservation model on top of the ledger and account services.
+package wallet
+
+import (
+	"context"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
+	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
+)
+
+const (
+	// ExternalDepositsAccount is the system account that funds user deposits.
+	ExternalDepositsAccount = "external:deposits"
+
+	// DefaultAsset is the default asset for wallet operations.
+	DefaultAsset = "BTC"
+)
+
+// Server implements the WalletService gRPC interface.
+type Server struct {
+	walletv1.UnimplementedWalletServiceServer
+	accounts accountv1.AccountServiceClient
+	ledger   ledgerv1.LedgerServiceClient
+	logger   *zap.Logger
+}
+
+// NewServer creates a new WalletService gRPC server.
+func NewServer(accounts accountv1.AccountServiceClient, ledger ledgerv1.LedgerServiceClient, logger *zap.Logger) *Server {
+	return &Server{accounts: accounts, ledger: ledger, logger: logger}
+}
+
+// Deposit credits a user's account from the external deposits source.
+func (s *Server) Deposit(ctx context.Context, req *walletv1.DepositRequest) (*walletv1.DepositResponse, error) {
+	// Validate request.
+	if req.IdempotencyKey == "" {
+		return nil, status.Error(codes.InvalidArgument, "idempotency_key is required")
+	}
+	if req.UserId == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+	if req.Amount <= 0 {
+		return nil, status.Error(codes.InvalidArgument, "amount must be positive")
+	}
+
+	// Resolve user → ledger account ID.
+	acctResp, err := s.accounts.GetLedgerAccount(ctx, &accountv1.GetLedgerAccountRequest{
+		UserId: req.UserId,
+		Asset:  DefaultAsset,
+	})
+	if err != nil {
+		return nil, mapDownstreamError(err, "resolving account")
+	}
+
+	// Post double-entry transaction via ledger.
+	txResp, err := s.ledger.PostTransaction(ctx, &ledgerv1.PostTransactionRequest{
+		IdempotencyKey: req.IdempotencyKey,
+		Postings: []*ledgerv1.Posting{
+			{AccountId: ExternalDepositsAccount, Asset: DefaultAsset, Amount: -req.Amount},
+			{AccountId: acctResp.LedgerAccountId, Asset: DefaultAsset, Amount: req.Amount},
+		},
+	})
+	if err != nil {
+		return nil, mapDownstreamError(err, "posting transaction")
+	}
+
+	s.logger.Info("deposit completed",
+		zap.String("user_id", req.UserId),
+		zap.String("tx_id", txResp.Transaction.Id),
+		zap.String("idempotency_key", req.IdempotencyKey),
+		zap.Int64("amount", req.Amount),
+	)
+
+	return &walletv1.DepositResponse{
+		TransactionId: txResp.Transaction.Id,
+	}, nil
+}
+
+// mapDownstreamError converts downstream gRPC errors to appropriate wallet-level codes.
+func mapDownstreamError(err error, context string) error {
+	st, ok := status.FromError(err)
+	if !ok {
+		return status.Errorf(codes.Internal, "%s: %v", context, err)
+	}
+
+	switch st.Code() {
+	case codes.NotFound:
+		return status.Error(codes.NotFound, st.Message())
+	case codes.InvalidArgument:
+		return status.Error(codes.InvalidArgument, st.Message())
+	case codes.FailedPrecondition:
+		return status.Error(codes.FailedPrecondition, st.Message())
+	default:
+		return status.Errorf(codes.Internal, "%s: %s", context, st.Message())
+	}
+}

--- a/internal/wallet/server_test.go
+++ b/internal/wallet/server_test.go
@@ -1,0 +1,310 @@
+package wallet_test
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/wallet"
+	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
+	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
+)
+
+// --- Mock clients ---
+
+type mockAccountClient struct {
+	accountv1.AccountServiceClient
+	getLedgerAccountFn func(ctx context.Context, in *accountv1.GetLedgerAccountRequest, opts ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error)
+}
+
+func (m *mockAccountClient) GetLedgerAccount(ctx context.Context, in *accountv1.GetLedgerAccountRequest, opts ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+	return m.getLedgerAccountFn(ctx, in, opts...)
+}
+
+type mockLedgerClient struct {
+	ledgerv1.LedgerServiceClient
+	postTransactionFn func(ctx context.Context, in *ledgerv1.PostTransactionRequest, opts ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error)
+}
+
+func (m *mockLedgerClient) PostTransaction(ctx context.Context, in *ledgerv1.PostTransactionRequest, opts ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+	return m.postTransactionFn(ctx, in, opts...)
+}
+
+// --- Helper ---
+
+func newTestServer(ac accountv1.AccountServiceClient, lc ledgerv1.LedgerServiceClient) *wallet.Server {
+	return wallet.NewServer(ac, lc, zap.NewNop())
+}
+
+// --- Validation tests ---
+
+func TestDeposit_MissingIdempotencyKey(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId: "user-1",
+		Amount: 1000,
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestDeposit_MissingUserID(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestDeposit_ZeroAmount(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         0,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestDeposit_NegativeAmount(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         -500,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+// --- Downstream error tests ---
+
+func TestDeposit_UserNotFound(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "user not found")
+		},
+	}
+	srv := newTestServer(ac, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "nonexistent",
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestDeposit_AccountServiceInternalError(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return nil, status.Error(codes.Unavailable, "connection refused")
+		},
+	}
+	srv := newTestServer(ac, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.Internal {
+		t.Errorf("code = %v, want Internal", st.Code())
+	}
+}
+
+func TestDeposit_LedgerError(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return &accountv1.GetLedgerAccountResponse{LedgerAccountId: "user:user-1"}, nil
+		},
+	}
+	lc := &mockLedgerClient{
+		postTransactionFn: func(_ context.Context, _ *ledgerv1.PostTransactionRequest, _ ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+			return nil, status.Error(codes.FailedPrecondition, "overdraft")
+		},
+	}
+	srv := newTestServer(ac, lc)
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.FailedPrecondition {
+		t.Errorf("code = %v, want FailedPrecondition", st.Code())
+	}
+}
+
+// --- Success tests ---
+
+func TestDeposit_Success(t *testing.T) {
+	t.Parallel()
+
+	var capturedPostings []*ledgerv1.Posting
+	var capturedKey string
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, req *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			if req.UserId != "user-1" {
+				t.Errorf("GetLedgerAccount user_id = %q, want %q", req.UserId, "user-1")
+			}
+			if req.Asset != wallet.DefaultAsset {
+				t.Errorf("GetLedgerAccount asset = %q, want %q", req.Asset, wallet.DefaultAsset)
+			}
+			return &accountv1.GetLedgerAccountResponse{LedgerAccountId: "user:user-1"}, nil
+		},
+	}
+	lc := &mockLedgerClient{
+		postTransactionFn: func(_ context.Context, req *ledgerv1.PostTransactionRequest, _ ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+			capturedPostings = req.Postings
+			capturedKey = req.IdempotencyKey
+			return &ledgerv1.PostTransactionResponse{
+				Transaction: &ledgerv1.Transaction{Id: "tx-abc"},
+			}, nil
+		},
+	}
+	srv := newTestServer(ac, lc)
+
+	resp, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         5000,
+		IdempotencyKey: "deposit-key-1",
+	})
+	if err != nil {
+		t.Fatalf("Deposit: %v", err)
+	}
+	if resp.TransactionId != "tx-abc" {
+		t.Errorf("transaction_id = %q, want %q", resp.TransactionId, "tx-abc")
+	}
+	if capturedKey != "deposit-key-1" {
+		t.Errorf("idempotency_key = %q, want %q", capturedKey, "deposit-key-1")
+	}
+
+	// Verify postings structure: debit external, credit user.
+	if len(capturedPostings) != 2 {
+		t.Fatalf("postings count = %d, want 2", len(capturedPostings))
+	}
+
+	debit := capturedPostings[0]
+	if debit.AccountId != wallet.ExternalDepositsAccount {
+		t.Errorf("debit account = %q, want %q", debit.AccountId, wallet.ExternalDepositsAccount)
+	}
+	if debit.Asset != wallet.DefaultAsset {
+		t.Errorf("debit asset = %q, want %q", debit.Asset, wallet.DefaultAsset)
+	}
+	if debit.Amount != -5000 {
+		t.Errorf("debit amount = %d, want %d", debit.Amount, -5000)
+	}
+
+	credit := capturedPostings[1]
+	if credit.AccountId != "user:user-1" {
+		t.Errorf("credit account = %q, want %q", credit.AccountId, "user:user-1")
+	}
+	if credit.Asset != wallet.DefaultAsset {
+		t.Errorf("credit asset = %q, want %q", credit.Asset, wallet.DefaultAsset)
+	}
+	if credit.Amount != 5000 {
+		t.Errorf("credit amount = %d, want %d", credit.Amount, 5000)
+	}
+}
+
+func TestDeposit_IdempotentReplay(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return &accountv1.GetLedgerAccountResponse{LedgerAccountId: "user:user-1"}, nil
+		},
+	}
+	lc := &mockLedgerClient{
+		postTransactionFn: func(_ context.Context, _ *ledgerv1.PostTransactionRequest, _ ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+			// Ledger handles idempotency transparently — returns the same tx.
+			return &ledgerv1.PostTransactionResponse{
+				Transaction: &ledgerv1.Transaction{Id: "tx-replay"},
+			}, nil
+		},
+	}
+	srv := newTestServer(ac, lc)
+
+	req := &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
+		IdempotencyKey: "replay-key",
+	}
+
+	resp1, err := srv.Deposit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Deposit (first): %v", err)
+	}
+	resp2, err := srv.Deposit(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Deposit (replay): %v", err)
+	}
+	if resp1.TransactionId != resp2.TransactionId {
+		t.Errorf("replay tx_id = %q, want %q", resp2.TransactionId, resp1.TransactionId)
+	}
+}

--- a/proto/wallet/v1/wallet.proto
+++ b/proto/wallet/v1/wallet.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package wallet.v1;
+
+option go_package = "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1;walletv1";
+
+service WalletService {
+  // Deposit credits a user's account from the external deposits source.
+  // Idempotent: the idempotency_key is forwarded to the ledger.
+  rpc Deposit(DepositRequest) returns (DepositResponse);
+}
+
+message DepositRequest {
+  string user_id = 1;
+  int64 amount = 2; // satoshis, must be > 0
+  string reference = 3; // caller-supplied reference
+  string idempotency_key = 4;
+}
+
+message DepositResponse {
+  string transaction_id = 1;
+}


### PR DESCRIPTION
## Summary
- Implement wallet `Deposit` RPC: validates request, resolves user→ledger account via account service, posts double-entry transaction via ledger service
- Wallet is a pure orchestrator — no database, idempotency delegated to ledger
- Fix ledger overdraft check to exempt `external:` accounts (bookkeeping counterparties that go negative by design)
- Add `AccountID.OverdraftExempt()` domain method so the naming convention lives in one place
- Wire `cmd/wallet/main.go` with full bootstrap (observability, gRPC clients to account/ledger, health server)

## Changes
- `internal/ledger/domain.go` — Add `OverdraftExempt()` method on `AccountID`
- `internal/ledger/mysql_repository.go` — Filter balances through `OverdraftExempt()` before overdraft check
- `proto/wallet/v1/wallet.proto` — New `WalletService` with `Deposit` RPC
- `internal/wallet/server.go` — Deposit orchestration implementation
- `internal/wallet/server_test.go` — 9 unit tests (validation, downstream errors, success, idempotency)
- `internal/wallet/grpc_test.go` — 3 bufconn integration tests
- `cmd/wallet/main.go` — Full service bootstrap

## Test plan
- [x] 12 wallet tests pass (9 unit + 3 bufconn integration)
- [x] All 57 unit tests pass across all packages
- [x] Lint clean, all 5 service binaries build
- [ ] Integration tests require `make up` (MySQL)

Closes #11