### PR TITLE
T3.4 Asset registry service (in-memory, gRPC API)

### DIFF
--- a/.claude/skills/health-check/SKILL.md
+++ b/.claude/skills/health-check/SKILL.md
@@ -20,6 +20,7 @@ Check the health and status of all running services.
    - Ledger: http://localhost:9091/metrics
    - Account: http://localhost:9092/metrics
    - Wallet: http://localhost:9093/metrics
+   - Asset: http://localhost:9095/metrics
    - Gateway: http://localhost:9094/metrics
 
 3. Check infrastructure services:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,13 @@ Microservices-based cryptocurrency exchange ledger demonstrating double-entry ac
 │ (metrics :9093) │      │ (metrics :9092) │
 └────────┬────────┘      └─────────────────┘
          │ gRPC                   │
-         ▼                        │
-┌─────────────────┐               │
-│ Ledger :9001    │←──────────────┘
-│ (metrics :9091) │
-└────────┬────────┘
-         │
+         ├───────────────┐        │
+         ▼               ▼        │
+┌─────────────────┐ ┌──────────────────┐
+│ Ledger :9001    │ │ Asset :9004      │
+│ (metrics :9091) │ │ (metrics :9095)  │
+└────────┬────────┘ └──────────────────┘
+         │                (in-memory)
          ▼
       [MySQL 8]
 ```
@@ -31,6 +32,7 @@ Microservices-based cryptocurrency exchange ledger demonstrating double-entry ac
 **Services:**
 - **Ledger** - Core double-entry accounting, balance tracking, overdraft prevention
 - **Account** - User identity, maps users to ledger account IDs
+- **Asset** - In-memory registry of supported assets (symbol, decimals, active)
 - **Wallet** - Deposit/withdrawal orchestration, reservation model
 - **Gateway** - REST facade, translates HTTP to gRPC
 
@@ -166,4 +168,5 @@ make up             # Start everything
 | Ledger  | 9001      | 9091         |
 | Account | 9002      | 9092         |
 | Wallet  | 9003      | 9093         |
+| Asset   | 9004      | 9095         |
 | Gateway | 8080 (HTTP) | 9094       |

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,8 @@ build:
 	go build -o bin/wallet ./cmd/wallet
 	@echo "Building gateway service..."
 	go build -o bin/gateway ./cmd/gateway
+	@echo "Building asset service..."
+	go build -o bin/asset ./cmd/asset
 	@echo "Building migrate tool..."
 	go build -o bin/migrate ./cmd/migrate
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This monorepo contains the following services:
 
 - **Ledger Service** - Core double-entry accounting ledger with ACID guarantees
 - **Account Service** - User identity and account management
+- **Asset Service** - In-memory asset registry (symbols, decimals, active status)
 - **Wallet Service** - Deposit/withdrawal orchestration
 - **Gateway Service** - HTTP REST API gateway
 
@@ -62,6 +63,7 @@ make down
 ├── cmd/                    # Service entrypoints
 │   ├── ledger/            # Ledger service main
 │   ├── account/           # Account service main
+│   ├── asset/             # Asset registry service main
 │   ├── wallet/            # Wallet service main
 │   └── gateway/           # Gateway service main
 ├── internal/              # Private application code
@@ -70,6 +72,7 @@ make down
 │   │   └── grpc/          # gRPC server/client helpers
 │   ├── ledger/            # Ledger domain logic
 │   ├── account/           # Account domain logic
+│   ├── asset/             # Asset registry domain logic
 │   └── wallet/            # Wallet domain logic
 ├── proto/                 # Protocol Buffer definitions
 ├── deploy/                # Deployment configurations

--- a/cmd/asset/main.go
+++ b/cmd/asset/main.go
@@ -1,5 +1,5 @@
-// Package main is the entry point for the wallet service.
-// The wallet service handles deposit and withdrawal orchestration.
+// Package main is the entry point for the asset registry service.
+// The asset service provides an in-memory catalogue of supported assets.
 package main
 
 import (
@@ -14,25 +14,20 @@ import (
 	"time"
 
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
+	"github.com/CLAM101/exchange-ledger-platform/internal/asset"
 	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
 	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
-	"github.com/CLAM101/exchange-ledger-platform/internal/wallet"
-	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
 	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
-	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
-	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
 )
 
-const serviceName = "wallet"
+const serviceName = "asset"
 
 func main() {
 	if err := run(); err != nil {
-		log.Fatalf("failed to run wallet service: %v", err)
+		log.Fatalf("failed to run asset service: %v", err)
 	}
 }
 
@@ -53,7 +48,7 @@ func run() error {
 	go func() {
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", metrics.Handler())
-		metricsPort := getEnv("METRICS_PORT", "9093")
+		metricsPort := getEnv("METRICS_PORT", "9095")
 		server := &http.Server{
 			Addr:              ":" + metricsPort,
 			Handler:           mux,
@@ -71,43 +66,16 @@ func run() error {
 
 	go func() {
 		<-sigChan
-		logger.Info("shutting down wallet service...")
+		logger.Info("shutting down asset service...")
 		cancel()
 	}()
 
-	// Connect to Account service.
-	accountAddr := getEnv("ACCOUNT_ADDR", "localhost:9002")
-	accountConn, err := grpc.NewClient(accountAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("connecting to account service: %w", err)
-	}
-	defer accountConn.Close() //nolint:errcheck // Best-effort close on shutdown
-	logger.Info("connected to account service", zap.String("addr", accountAddr))
-
-	// Connect to Asset service.
-	assetAddr := getEnv("ASSET_ADDR", "localhost:9004")
-	assetConn, err := grpc.NewClient(assetAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("connecting to asset service: %w", err)
-	}
-	defer assetConn.Close() //nolint:errcheck // Best-effort close on shutdown
-	logger.Info("connected to asset service", zap.String("addr", assetAddr))
-
-	// Connect to Ledger service.
-	ledgerAddr := getEnv("LEDGER_ADDR", "localhost:9001")
-	ledgerConn, err := grpc.NewClient(ledgerAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return fmt.Errorf("connecting to ledger service: %w", err)
-	}
-	defer ledgerConn.Close() //nolint:errcheck // Best-effort close on shutdown
-	logger.Info("connected to ledger service", zap.String("addr", ledgerAddr))
-
-	// Health service (no DB checker — wallet is stateless).
+	// Health service (no DB — asset is stateless).
 	hs := health.NewServer()
 	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	hs.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 
-	port := getEnv("GRPC_PORT", "9003")
+	port := getEnv("GRPC_PORT", "9004")
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%s", port))
 	if err != nil {
 		return fmt.Errorf("failed to listen: %w", err)
@@ -115,13 +83,11 @@ func run() error {
 
 	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
 
-	accountClient := accountv1.NewAccountServiceClient(accountConn)
-	assetClient := assetv1.NewAssetServiceClient(assetConn)
-	ledgerClient := ledgerv1.NewLedgerServiceClient(ledgerConn)
-	handler := wallet.NewServer(accountClient, assetClient, ledgerClient, logger)
-	walletv1.RegisterWalletServiceServer(grpcServer, handler)
+	registry := asset.NewInMemoryRegistry(asset.DefaultAssets())
+	handler := asset.NewServer(registry, logger)
+	assetv1.RegisterAssetServiceServer(grpcServer, handler)
 
-	logger.Info("Wallet service listening", zap.String("port", port))
+	logger.Info("Asset service listening", zap.String("port", port))
 
 	// Start gRPC server.
 	errChan := make(chan error, 1)

--- a/deploy/prometheus.yml
+++ b/deploy/prometheus.yml
@@ -19,3 +19,7 @@ scrape_configs:
     static_configs:
       - targets: ['gateway:9094']
 
+  - job_name: 'asset'
+    static_configs:
+      - targets: ['asset:9095']
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,24 @@ services:
       timeout: 5s
       retries: 5
 
+  # Asset Service (in-memory registry, no DB)
+  asset:
+    build:
+      context: .
+      dockerfile: cmd/asset/Dockerfile
+    container_name: exchange-asset
+    environment:
+      - GRPC_PORT=9004
+      - METRICS_PORT=9095
+    ports:
+      - "9004:9004"
+      - "9095:9095"
+    healthcheck:
+      test: ["CMD", "grpc_health_probe", "-addr=:9004"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # Wallet Service
   wallet:
     build:
@@ -99,6 +117,7 @@ services:
       - DB_NAME=ledger
       - LEDGER_ADDR=ledger:9001
       - ACCOUNT_ADDR=account:9002
+      - ASSET_ADDR=asset:9004
       - GRPC_PORT=9003
       - METRICS_PORT=9093
     ports:
@@ -108,6 +127,8 @@ services:
       ledger:
         condition: service_healthy
       account:
+        condition: service_healthy
+      asset:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "grpc_health_probe", "-addr=:9003"]

--- a/internal/account/domain.go
+++ b/internal/account/domain.go
@@ -26,9 +26,6 @@ type UserAssetAccount struct {
 	CreatedAt       time.Time
 }
 
-// DefaultAsset is the asset automatically linked when a user is created.
-const DefaultAsset = "BTC"
-
 // LedgerAccountID returns the deterministic ledger account ID for a user.
 func LedgerAccountID(id UserID) string {
 	return "user:" + string(id)

--- a/internal/account/grpc_test.go
+++ b/internal/account/grpc_test.go
@@ -73,9 +73,6 @@ func TestGRPC_CreateUser_Success(t *testing.T) {
 				CreatedAt:      now,
 			}, nil
 		},
-		linkAssetFn: func(_ context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
-			return &ua, nil
-		},
 	}
 
 	client := setupGRPC(t, repo)
@@ -185,5 +182,49 @@ func TestGRPC_GetUser_NotFound(t *testing.T) {
 	}
 	if st.Code() != codes.NotFound {
 		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestGRPC_LinkAssetAccount_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := &mockRepo{
+		linkAssetFn: func(_ context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
+			return &ua, nil
+		},
+	}
+
+	client := setupGRPC(t, repo)
+
+	resp, err := client.LinkAssetAccount(context.Background(), &accountv1.LinkAssetAccountRequest{
+		UserId: "user-grpc-4",
+		Asset:  "ETH",
+	})
+	if err != nil {
+		t.Fatalf("LinkAssetAccount: %v", err)
+	}
+	if resp.LedgerAccountId != "user:user-grpc-4" {
+		t.Errorf("ledger_account_id = %q, want %q", resp.LedgerAccountId, "user:user-grpc-4")
+	}
+	if resp.Asset != "ETH" {
+		t.Errorf("asset = %q, want %q", resp.Asset, "ETH")
+	}
+}
+
+func TestGRPC_LinkAssetAccount_MissingAsset(t *testing.T) {
+	t.Parallel()
+
+	client := setupGRPC(t, &mockRepo{})
+
+	_, err := client.LinkAssetAccount(context.Background(), &accountv1.LinkAssetAccountRequest{
+		UserId: "user-grpc-4",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
 	}
 }

--- a/internal/account/server.go
+++ b/internal/account/server.go
@@ -24,7 +24,7 @@ func NewServer(repo Repository, logger *zap.Logger) *Server {
 	return &Server{repo: repo, logger: logger}
 }
 
-// CreateUser registers a new user and auto-links the default BTC ledger account.
+// CreateUser registers a new user.
 func (s *Server) CreateUser(ctx context.Context, req *accountv1.CreateUserRequest) (*accountv1.CreateUserResponse, error) {
 	u := User{
 		Email:          req.Email,
@@ -41,19 +41,6 @@ func (s *Server) CreateUser(ctx context.Context, req *accountv1.CreateUserReques
 			zap.Error(err),
 		)
 		return nil, domainToStatus(err)
-	}
-
-	// Auto-link the default asset account.
-	if _, err := s.repo.LinkAssetAccount(ctx, UserAssetAccount{
-		UserID:          user.ID,
-		Asset:           DefaultAsset,
-		LedgerAccountID: LedgerAccountID(user.ID),
-	}); err != nil {
-		s.logger.Error("LinkAssetAccount failed after user creation",
-			zap.String("user_id", string(user.ID)),
-			zap.Error(err),
-		)
-		return nil, status.Error(codes.Internal, "failed to link asset account")
 	}
 
 	return &accountv1.CreateUserResponse{
@@ -95,6 +82,37 @@ func (s *Server) GetLedgerAccount(ctx context.Context, req *accountv1.GetLedgerA
 		UserId:          req.UserId,
 		Asset:           req.Asset,
 		LedgerAccountId: ledgerID,
+	}, nil
+}
+
+// LinkAssetAccount links a user to a ledger account for a given asset.
+func (s *Server) LinkAssetAccount(ctx context.Context, req *accountv1.LinkAssetAccountRequest) (*accountv1.LinkAssetAccountResponse, error) {
+	if req.UserId == "" {
+		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	}
+	if req.Asset == "" {
+		return nil, status.Error(codes.InvalidArgument, "asset is required")
+	}
+
+	uid := UserID(req.UserId)
+	ua, err := s.repo.LinkAssetAccount(ctx, UserAssetAccount{
+		UserID:          uid,
+		Asset:           req.Asset,
+		LedgerAccountID: LedgerAccountID(uid),
+	})
+	if err != nil {
+		s.logger.Warn("LinkAssetAccount failed",
+			zap.String("user_id", req.UserId),
+			zap.String("asset", req.Asset),
+			zap.Error(err),
+		)
+		return nil, domainToStatus(err)
+	}
+
+	return &accountv1.LinkAssetAccountResponse{
+		UserId:          req.UserId,
+		Asset:           ua.Asset,
+		LedgerAccountId: ua.LedgerAccountID,
 	}, nil
 }
 

--- a/internal/account/server_test.go
+++ b/internal/account/server_test.go
@@ -105,10 +105,6 @@ func TestCreateUser_Success(t *testing.T) {
 	t.Parallel()
 	now := time.Now()
 
-	var linkCalled bool
-	var linkedAsset string
-	var linkedLedgerID string
-
 	repo := &mockRepo{
 		createUserFn: func(_ context.Context, u account.User) (*account.User, error) {
 			return &account.User{
@@ -117,12 +113,6 @@ func TestCreateUser_Success(t *testing.T) {
 				IdempotencyKey: u.IdempotencyKey,
 				CreatedAt:      now,
 			}, nil
-		},
-		linkAssetFn: func(_ context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
-			linkCalled = true
-			linkedAsset = ua.Asset
-			linkedLedgerID = ua.LedgerAccountID
-			return &ua, nil
 		},
 	}
 	srv := newTestServer(repo)
@@ -139,15 +129,6 @@ func TestCreateUser_Success(t *testing.T) {
 	}
 	if resp.User.Email != "alice@example.com" {
 		t.Errorf("email = %q, want %q", resp.User.Email, "alice@example.com")
-	}
-	if !linkCalled {
-		t.Error("LinkAssetAccount was not called")
-	}
-	if linkedAsset != account.DefaultAsset {
-		t.Errorf("linked asset = %q, want %q", linkedAsset, account.DefaultAsset)
-	}
-	if linkedLedgerID != "user:user-abc" {
-		t.Errorf("linked ledger ID = %q, want %q", linkedLedgerID, "user:user-abc")
 	}
 }
 
@@ -348,5 +329,74 @@ func TestGetLedgerAccount_NotFound(t *testing.T) {
 	}
 	if st.Code() != codes.NotFound {
 		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+// --- LinkAssetAccount tests ---
+
+func TestLinkAssetAccount_MissingUserID(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.LinkAssetAccount(context.Background(), &accountv1.LinkAssetAccountRequest{
+		Asset: "BTC",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestLinkAssetAccount_MissingAsset(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRepo{})
+
+	_, err := srv.LinkAssetAccount(context.Background(), &accountv1.LinkAssetAccountRequest{
+		UserId: "user-abc",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestLinkAssetAccount_Success(t *testing.T) {
+	t.Parallel()
+
+	var capturedUA account.UserAssetAccount
+	repo := &mockRepo{
+		linkAssetFn: func(_ context.Context, ua account.UserAssetAccount) (*account.UserAssetAccount, error) {
+			capturedUA = ua
+			return &ua, nil
+		},
+	}
+	srv := newTestServer(repo)
+
+	resp, err := srv.LinkAssetAccount(context.Background(), &accountv1.LinkAssetAccountRequest{
+		UserId: "user-abc",
+		Asset:  "ETH",
+	})
+	if err != nil {
+		t.Fatalf("LinkAssetAccount: %v", err)
+	}
+	if resp.UserId != "user-abc" {
+		t.Errorf("user_id = %q, want %q", resp.UserId, "user-abc")
+	}
+	if resp.Asset != "ETH" {
+		t.Errorf("asset = %q, want %q", resp.Asset, "ETH")
+	}
+	if resp.LedgerAccountId != "user:user-abc" {
+		t.Errorf("ledger_account_id = %q, want %q", resp.LedgerAccountId, "user:user-abc")
+	}
+	if capturedUA.UserID != "user-abc" {
+		t.Errorf("repo user_id = %q, want %q", capturedUA.UserID, "user-abc")
 	}
 }

--- a/internal/asset/domain.go
+++ b/internal/asset/domain.go
@@ -1,0 +1,61 @@
+// Package asset implements an in-memory asset registry for the exchange platform.
+package asset
+
+import "errors"
+
+// Asset represents a tradeable asset with its configuration.
+type Asset struct {
+	Symbol   string
+	Decimals int32
+	Active   bool
+}
+
+// Registry provides read access to the asset catalogue.
+type Registry interface {
+	Get(symbol string) (Asset, error)
+	List() []Asset
+}
+
+// ErrNotFound is returned when an asset symbol is not in the registry.
+var ErrNotFound = errors.New("asset not found")
+
+// InMemoryRegistry is a Registry backed by a static map.
+type InMemoryRegistry struct {
+	assets map[string]Asset
+}
+
+// NewInMemoryRegistry creates a registry pre-seeded with the given assets.
+func NewInMemoryRegistry(seed []Asset) *InMemoryRegistry {
+	m := make(map[string]Asset, len(seed))
+	for _, a := range seed {
+		m[a.Symbol] = a
+	}
+	return &InMemoryRegistry{assets: m}
+}
+
+// DefaultAssets returns the platform's built-in asset list.
+func DefaultAssets() []Asset {
+	return []Asset{
+		{Symbol: "BTC", Decimals: 8, Active: true},
+		{Symbol: "ETH", Decimals: 18, Active: true},
+		{Symbol: "USDC", Decimals: 6, Active: true},
+	}
+}
+
+// Get returns the asset for the given symbol or ErrNotFound.
+func (r *InMemoryRegistry) Get(symbol string) (Asset, error) {
+	a, ok := r.assets[symbol]
+	if !ok {
+		return Asset{}, ErrNotFound
+	}
+	return a, nil
+}
+
+// List returns all registered assets.
+func (r *InMemoryRegistry) List() []Asset {
+	out := make([]Asset, 0, len(r.assets))
+	for _, a := range r.assets {
+		out = append(out, a)
+	}
+	return out
+}

--- a/internal/asset/domain_test.go
+++ b/internal/asset/domain_test.go
@@ -1,0 +1,57 @@
+package asset_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/asset"
+)
+
+func TestInMemoryRegistry_Get_Known(t *testing.T) {
+	t.Parallel()
+	reg := asset.NewInMemoryRegistry(asset.DefaultAssets())
+
+	a, err := reg.Get("BTC")
+	if err != nil {
+		t.Fatalf("Get(BTC): %v", err)
+	}
+	if a.Symbol != "BTC" {
+		t.Errorf("symbol = %q, want %q", a.Symbol, "BTC")
+	}
+	if a.Decimals != 8 {
+		t.Errorf("decimals = %d, want %d", a.Decimals, 8)
+	}
+	if !a.Active {
+		t.Error("expected active = true")
+	}
+}
+
+func TestInMemoryRegistry_Get_Unknown(t *testing.T) {
+	t.Parallel()
+	reg := asset.NewInMemoryRegistry(asset.DefaultAssets())
+
+	_, err := reg.Get("DOGE")
+	if !errors.Is(err, asset.ErrNotFound) {
+		t.Errorf("err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestInMemoryRegistry_List(t *testing.T) {
+	t.Parallel()
+	reg := asset.NewInMemoryRegistry(asset.DefaultAssets())
+
+	assets := reg.List()
+	if len(assets) != 3 {
+		t.Fatalf("len = %d, want 3", len(assets))
+	}
+
+	symbols := make(map[string]bool)
+	for _, a := range assets {
+		symbols[a.Symbol] = true
+	}
+	for _, want := range []string{"BTC", "ETH", "USDC"} {
+		if !symbols[want] {
+			t.Errorf("missing asset %q", want)
+		}
+	}
+}

--- a/internal/asset/grpc_test.go
+++ b/internal/asset/grpc_test.go
@@ -1,0 +1,120 @@
+package asset_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/asset"
+	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
+	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
+
+	platformgrpc "github.com/CLAM101/exchange-ledger-platform/internal/platform/grpc"
+)
+
+const bufSize = 1024 * 1024
+
+// setupGRPC creates an in-memory gRPC server+client pair with the given registry.
+func setupGRPC(t *testing.T, reg asset.Registry) assetv1.AssetServiceClient {
+	t.Helper()
+
+	logger := zap.NewNop()
+	metrics := observability.NewTestMetrics()
+	hs := health.NewServer()
+	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
+
+	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
+	handler := asset.NewServer(reg, logger)
+	assetv1.RegisterAssetServiceServer(grpcServer, handler)
+
+	lis := bufconn.Listen(bufSize)
+	go func() {
+		if err := grpcServer.Serve(lis); err != nil {
+			t.Logf("gRPC server exited: %v", err)
+		}
+	}()
+	t.Cleanup(func() { grpcServer.Stop() })
+
+	conn, err := grpc.NewClient(
+		"passthrough:///bufconn",
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return lis.DialContext(ctx)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("grpc.NewClient: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	return assetv1.NewAssetServiceClient(conn)
+}
+
+func TestGRPC_GetAsset_Success(t *testing.T) {
+	t.Parallel()
+	reg := asset.NewInMemoryRegistry(asset.DefaultAssets())
+	client := setupGRPC(t, reg)
+
+	resp, err := client.GetAsset(context.Background(), &assetv1.GetAssetRequest{Symbol: "BTC"})
+	if err != nil {
+		t.Fatalf("GetAsset: %v", err)
+	}
+	if resp.Asset.Symbol != "BTC" {
+		t.Errorf("symbol = %q, want %q", resp.Asset.Symbol, "BTC")
+	}
+	if resp.Asset.Decimals != 8 {
+		t.Errorf("decimals = %d, want %d", resp.Asset.Decimals, 8)
+	}
+	if !resp.Asset.Active {
+		t.Error("expected active = true")
+	}
+}
+
+func TestGRPC_GetAsset_NotFound(t *testing.T) {
+	t.Parallel()
+	reg := asset.NewInMemoryRegistry(asset.DefaultAssets())
+	client := setupGRPC(t, reg)
+
+	_, err := client.GetAsset(context.Background(), &assetv1.GetAssetRequest{Symbol: "DOGE"})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestGRPC_ListAssets_ReturnsAll(t *testing.T) {
+	t.Parallel()
+	reg := asset.NewInMemoryRegistry(asset.DefaultAssets())
+	client := setupGRPC(t, reg)
+
+	resp, err := client.ListAssets(context.Background(), &assetv1.ListAssetsRequest{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	if len(resp.Assets) != 3 {
+		t.Fatalf("len = %d, want 3", len(resp.Assets))
+	}
+
+	symbols := make(map[string]bool)
+	for _, a := range resp.Assets {
+		symbols[a.Symbol] = true
+	}
+	for _, want := range []string{"BTC", "ETH", "USDC"} {
+		if !symbols[want] {
+			t.Errorf("missing asset %q", want)
+		}
+	}
+}

--- a/internal/asset/server.go
+++ b/internal/asset/server.go
@@ -1,0 +1,68 @@
+package asset
+
+import (
+	"context"
+	"errors"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
+)
+
+// Server implements the AssetService gRPC interface.
+type Server struct {
+	assetv1.UnimplementedAssetServiceServer
+	registry Registry
+	logger   *zap.Logger
+}
+
+// NewServer creates a new AssetService gRPC server.
+func NewServer(registry Registry, logger *zap.Logger) *Server {
+	return &Server{registry: registry, logger: logger}
+}
+
+// GetAsset returns a single asset by symbol.
+func (s *Server) GetAsset(_ context.Context, req *assetv1.GetAssetRequest) (*assetv1.GetAssetResponse, error) {
+	if req.Symbol == "" {
+		return nil, status.Error(codes.InvalidArgument, "symbol is required")
+	}
+
+	a, err := s.registry.Get(req.Symbol)
+	if err != nil {
+		return nil, domainToStatus(err)
+	}
+
+	return &assetv1.GetAssetResponse{
+		Asset: assetToProto(a),
+	}, nil
+}
+
+// ListAssets returns all registered assets.
+func (s *Server) ListAssets(_ context.Context, _ *assetv1.ListAssetsRequest) (*assetv1.ListAssetsResponse, error) {
+	assets := s.registry.List()
+	out := make([]*assetv1.Asset, len(assets))
+	for i, a := range assets {
+		out[i] = assetToProto(a)
+	}
+	return &assetv1.ListAssetsResponse{Assets: out}, nil
+}
+
+// domainToStatus maps domain errors to gRPC status codes.
+func domainToStatus(err error) error {
+	switch {
+	case errors.Is(err, ErrNotFound):
+		return status.Error(codes.NotFound, err.Error())
+	default:
+		return status.Error(codes.Internal, "internal error")
+	}
+}
+
+func assetToProto(a Asset) *assetv1.Asset {
+	return &assetv1.Asset{
+		Symbol:   a.Symbol,
+		Decimals: a.Decimals,
+		Active:   a.Active,
+	}
+}

--- a/internal/asset/server_test.go
+++ b/internal/asset/server_test.go
@@ -1,0 +1,118 @@
+package asset_test
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/CLAM101/exchange-ledger-platform/internal/asset"
+	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
+)
+
+// mockRegistry is a test double for asset.Registry.
+type mockRegistry struct {
+	getFn  func(symbol string) (asset.Asset, error)
+	listFn func() []asset.Asset
+}
+
+func (m *mockRegistry) Get(symbol string) (asset.Asset, error) {
+	return m.getFn(symbol)
+}
+
+func (m *mockRegistry) List() []asset.Asset {
+	return m.listFn()
+}
+
+func newTestServer(reg asset.Registry) *asset.Server {
+	return asset.NewServer(reg, zap.NewNop())
+}
+
+// --- GetAsset tests ---
+
+func TestGetAsset_MissingSymbol(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockRegistry{})
+
+	_, err := srv.GetAsset(context.Background(), &assetv1.GetAssetRequest{})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestGetAsset_NotFound(t *testing.T) {
+	t.Parallel()
+	reg := &mockRegistry{
+		getFn: func(_ string) (asset.Asset, error) {
+			return asset.Asset{}, asset.ErrNotFound
+		},
+	}
+	srv := newTestServer(reg)
+
+	_, err := srv.GetAsset(context.Background(), &assetv1.GetAssetRequest{Symbol: "DOGE"})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestGetAsset_Success(t *testing.T) {
+	t.Parallel()
+	reg := &mockRegistry{
+		getFn: func(symbol string) (asset.Asset, error) {
+			return asset.Asset{Symbol: symbol, Decimals: 8, Active: true}, nil
+		},
+	}
+	srv := newTestServer(reg)
+
+	resp, err := srv.GetAsset(context.Background(), &assetv1.GetAssetRequest{Symbol: "BTC"})
+	if err != nil {
+		t.Fatalf("GetAsset: %v", err)
+	}
+	if resp.Asset.Symbol != "BTC" {
+		t.Errorf("symbol = %q, want %q", resp.Asset.Symbol, "BTC")
+	}
+	if resp.Asset.Decimals != 8 {
+		t.Errorf("decimals = %d, want %d", resp.Asset.Decimals, 8)
+	}
+	if !resp.Asset.Active {
+		t.Error("expected active = true")
+	}
+}
+
+// --- ListAssets tests ---
+
+func TestListAssets_Success(t *testing.T) {
+	t.Parallel()
+	reg := &mockRegistry{
+		listFn: func() []asset.Asset {
+			return []asset.Asset{
+				{Symbol: "BTC", Decimals: 8, Active: true},
+				{Symbol: "ETH", Decimals: 18, Active: true},
+			}
+		},
+	}
+	srv := newTestServer(reg)
+
+	resp, err := srv.ListAssets(context.Background(), &assetv1.ListAssetsRequest{})
+	if err != nil {
+		t.Fatalf("ListAssets: %v", err)
+	}
+	if len(resp.Assets) != 2 {
+		t.Fatalf("len = %d, want 2", len(resp.Assets))
+	}
+	if resp.Assets[0].Symbol != "BTC" {
+		t.Errorf("assets[0].symbol = %q, want %q", resp.Assets[0].Symbol, "BTC")
+	}
+}

--- a/internal/wallet/grpc_test.go
+++ b/internal/wallet/grpc_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/CLAM101/exchange-ledger-platform/internal/platform/observability"
 	"github.com/CLAM101/exchange-ledger-platform/internal/wallet"
 	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
 	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
 	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
 
@@ -26,7 +27,7 @@ import (
 const bufSize = 1024 * 1024
 
 // setupGRPC creates an in-memory gRPC server+client pair for the wallet service.
-func setupGRPC(t *testing.T, ac accountv1.AccountServiceClient, lc ledgerv1.LedgerServiceClient) walletv1.WalletServiceClient {
+func setupGRPC(t *testing.T, ac accountv1.AccountServiceClient, asc assetv1.AssetServiceClient, lc ledgerv1.LedgerServiceClient) walletv1.WalletServiceClient {
 	t.Helper()
 
 	logger := zap.NewNop()
@@ -35,7 +36,7 @@ func setupGRPC(t *testing.T, ac accountv1.AccountServiceClient, lc ledgerv1.Ledg
 	hs.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 
 	grpcServer := platformgrpc.NewServer(logger, metrics, hs)
-	handler := wallet.NewServer(ac, lc, logger)
+	handler := wallet.NewServer(ac, asc, lc, logger)
 	walletv1.RegisterWalletServiceServer(grpcServer, handler)
 
 	lis := bufconn.Listen(bufSize)
@@ -77,12 +78,13 @@ func TestGRPC_Deposit_Success(t *testing.T) {
 		},
 	}
 
-	client := setupGRPC(t, ac, lc)
+	client := setupGRPC(t, ac, validAssetClient(), lc)
 
 	resp, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         3000,
 		IdempotencyKey: "grpc-key-1",
+		Asset:          "BTC",
 	})
 	if err != nil {
 		t.Fatalf("Deposit: %v", err)
@@ -95,11 +97,12 @@ func TestGRPC_Deposit_Success(t *testing.T) {
 func TestGRPC_Deposit_InvalidArgument(t *testing.T) {
 	t.Parallel()
 
-	client := setupGRPC(t, &mockAccountClient{}, &mockLedgerClient{})
+	client := setupGRPC(t, &mockAccountClient{}, validAssetClient(), &mockLedgerClient{})
 
 	_, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
 		Amount:         1000,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
 		// Missing user_id
 	})
 
@@ -117,16 +120,86 @@ func TestGRPC_Deposit_UserNotFound(t *testing.T) {
 
 	ac := &mockAccountClient{
 		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+		linkAssetAccountFn: func(_ context.Context, _ *accountv1.LinkAssetAccountRequest, _ ...grpc.CallOption) (*accountv1.LinkAssetAccountResponse, error) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		},
 	}
 
-	client := setupGRPC(t, ac, &mockLedgerClient{})
+	client := setupGRPC(t, ac, validAssetClient(), &mockLedgerClient{})
 
 	_, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "nonexistent",
 		Amount:         1000,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
+func TestGRPC_Deposit_LazyLinkSuccess(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+		linkAssetAccountFn: func(_ context.Context, req *accountv1.LinkAssetAccountRequest, _ ...grpc.CallOption) (*accountv1.LinkAssetAccountResponse, error) {
+			return &accountv1.LinkAssetAccountResponse{
+				UserId:          req.UserId,
+				Asset:           req.Asset,
+				LedgerAccountId: "user:" + req.UserId,
+			}, nil
+		},
+	}
+	lc := &mockLedgerClient{
+		postTransactionFn: func(_ context.Context, _ *ledgerv1.PostTransactionRequest, _ ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+			return &ledgerv1.PostTransactionResponse{
+				Transaction: &ledgerv1.Transaction{Id: "tx-grpc-lazy"},
+			}, nil
+		},
+	}
+
+	client := setupGRPC(t, ac, validAssetClient(), lc)
+
+	resp, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
+		IdempotencyKey: "grpc-lazy-key",
+		Asset:          "ETH",
+	})
+	if err != nil {
+		t.Fatalf("Deposit: %v", err)
+	}
+	if resp.TransactionId != "tx-grpc-lazy" {
+		t.Errorf("transaction_id = %q, want %q", resp.TransactionId, "tx-grpc-lazy")
+	}
+}
+
+func TestGRPC_Deposit_UnknownAsset(t *testing.T) {
+	t.Parallel()
+
+	asc := &mockAssetClient{
+		getAssetFn: func(_ context.Context, _ *assetv1.GetAssetRequest, _ ...grpc.CallOption) (*assetv1.GetAssetResponse, error) {
+			return nil, status.Error(codes.NotFound, "asset not found")
+		},
+	}
+
+	client := setupGRPC(t, &mockAccountClient{}, asc, &mockLedgerClient{})
+
+	_, err := client.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+		Asset:          "DOGE",
 	})
 
 	st, ok := status.FromError(err)

--- a/internal/wallet/server.go
+++ b/internal/wallet/server.go
@@ -10,29 +10,26 @@ import (
 	"google.golang.org/grpc/status"
 
 	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
 	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
 	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
 )
 
-const (
-	// ExternalDepositsAccount is the system account that funds user deposits.
-	ExternalDepositsAccount = "external:deposits"
-
-	// DefaultAsset is the default asset for wallet operations.
-	DefaultAsset = "BTC"
-)
+// ExternalDepositsAccount is the system account that funds user deposits.
+const ExternalDepositsAccount = "external:deposits"
 
 // Server implements the WalletService gRPC interface.
 type Server struct {
 	walletv1.UnimplementedWalletServiceServer
 	accounts accountv1.AccountServiceClient
+	assets   assetv1.AssetServiceClient
 	ledger   ledgerv1.LedgerServiceClient
 	logger   *zap.Logger
 }
 
 // NewServer creates a new WalletService gRPC server.
-func NewServer(accounts accountv1.AccountServiceClient, ledger ledgerv1.LedgerServiceClient, logger *zap.Logger) *Server {
-	return &Server{accounts: accounts, ledger: ledger, logger: logger}
+func NewServer(accounts accountv1.AccountServiceClient, assets assetv1.AssetServiceClient, ledger ledgerv1.LedgerServiceClient, logger *zap.Logger) *Server {
+	return &Server{accounts: accounts, assets: assets, ledger: ledger, logger: logger}
 }
 
 // Deposit credits a user's account from the external deposits source.
@@ -47,22 +44,47 @@ func (s *Server) Deposit(ctx context.Context, req *walletv1.DepositRequest) (*wa
 	if req.Amount <= 0 {
 		return nil, status.Error(codes.InvalidArgument, "amount must be positive")
 	}
+	if req.Asset == "" {
+		return nil, status.Error(codes.InvalidArgument, "asset is required")
+	}
 
-	// Resolve user → ledger account ID.
+	// Validate asset exists in the registry.
+	if _, err := s.assets.GetAsset(ctx, &assetv1.GetAssetRequest{Symbol: req.Asset}); err != nil {
+		return nil, mapDownstreamError(err, "validating asset")
+	}
+
+	// Resolve user → ledger account ID, lazy-linking if this is the first
+	// deposit for this asset.
 	acctResp, err := s.accounts.GetLedgerAccount(ctx, &accountv1.GetLedgerAccountRequest{
 		UserId: req.UserId,
-		Asset:  DefaultAsset,
+		Asset:  req.Asset,
 	})
 	if err != nil {
-		return nil, mapDownstreamError(err, "resolving account")
+		st, ok := status.FromError(err)
+		if !ok || st.Code() != codes.NotFound {
+			return nil, mapDownstreamError(err, "resolving account")
+		}
+		// First deposit for this asset — create the link.
+		linkResp, linkErr := s.accounts.LinkAssetAccount(ctx, &accountv1.LinkAssetAccountRequest{
+			UserId: req.UserId,
+			Asset:  req.Asset,
+		})
+		if linkErr != nil {
+			return nil, mapDownstreamError(linkErr, "linking asset account")
+		}
+		acctResp = &accountv1.GetLedgerAccountResponse{
+			UserId:          linkResp.UserId,
+			Asset:           linkResp.Asset,
+			LedgerAccountId: linkResp.LedgerAccountId,
+		}
 	}
 
 	// Post double-entry transaction via ledger.
 	txResp, err := s.ledger.PostTransaction(ctx, &ledgerv1.PostTransactionRequest{
 		IdempotencyKey: req.IdempotencyKey,
 		Postings: []*ledgerv1.Posting{
-			{AccountId: ExternalDepositsAccount, Asset: DefaultAsset, Amount: -req.Amount},
-			{AccountId: acctResp.LedgerAccountId, Asset: DefaultAsset, Amount: req.Amount},
+			{AccountId: ExternalDepositsAccount, Asset: req.Asset, Amount: -req.Amount},
+			{AccountId: acctResp.LedgerAccountId, Asset: req.Asset, Amount: req.Amount},
 		},
 	})
 	if err != nil {
@@ -73,6 +95,7 @@ func (s *Server) Deposit(ctx context.Context, req *walletv1.DepositRequest) (*wa
 		zap.String("user_id", req.UserId),
 		zap.String("tx_id", txResp.Transaction.Id),
 		zap.String("idempotency_key", req.IdempotencyKey),
+		zap.String("asset", req.Asset),
 		zap.Int64("amount", req.Amount),
 	)
 

--- a/internal/wallet/server_test.go
+++ b/internal/wallet/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CLAM101/exchange-ledger-platform/internal/wallet"
 	accountv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/account/v1"
+	assetv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1"
 	ledgerv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/ledger/v1"
 	walletv1 "github.com/CLAM101/exchange-ledger-platform/proto/gen/wallet/v1"
 )
@@ -20,10 +21,24 @@ import (
 type mockAccountClient struct {
 	accountv1.AccountServiceClient
 	getLedgerAccountFn func(ctx context.Context, in *accountv1.GetLedgerAccountRequest, opts ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error)
+	linkAssetAccountFn func(ctx context.Context, in *accountv1.LinkAssetAccountRequest, opts ...grpc.CallOption) (*accountv1.LinkAssetAccountResponse, error)
 }
 
 func (m *mockAccountClient) GetLedgerAccount(ctx context.Context, in *accountv1.GetLedgerAccountRequest, opts ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
 	return m.getLedgerAccountFn(ctx, in, opts...)
+}
+
+func (m *mockAccountClient) LinkAssetAccount(ctx context.Context, in *accountv1.LinkAssetAccountRequest, opts ...grpc.CallOption) (*accountv1.LinkAssetAccountResponse, error) {
+	return m.linkAssetAccountFn(ctx, in, opts...)
+}
+
+type mockAssetClient struct {
+	assetv1.AssetServiceClient
+	getAssetFn func(ctx context.Context, in *assetv1.GetAssetRequest, opts ...grpc.CallOption) (*assetv1.GetAssetResponse, error)
+}
+
+func (m *mockAssetClient) GetAsset(ctx context.Context, in *assetv1.GetAssetRequest, opts ...grpc.CallOption) (*assetv1.GetAssetResponse, error) {
+	return m.getAssetFn(ctx, in, opts...)
 }
 
 type mockLedgerClient struct {
@@ -37,19 +52,31 @@ func (m *mockLedgerClient) PostTransaction(ctx context.Context, in *ledgerv1.Pos
 
 // --- Helper ---
 
-func newTestServer(ac accountv1.AccountServiceClient, lc ledgerv1.LedgerServiceClient) *wallet.Server {
-	return wallet.NewServer(ac, lc, zap.NewNop())
+// validAssetClient returns a mock that accepts any known asset.
+func validAssetClient() *mockAssetClient {
+	return &mockAssetClient{
+		getAssetFn: func(_ context.Context, req *assetv1.GetAssetRequest, _ ...grpc.CallOption) (*assetv1.GetAssetResponse, error) {
+			return &assetv1.GetAssetResponse{
+				Asset: &assetv1.Asset{Symbol: req.Symbol, Decimals: 8, Active: true},
+			}, nil
+		},
+	}
+}
+
+func newTestServer(ac accountv1.AccountServiceClient, asc assetv1.AssetServiceClient, lc ledgerv1.LedgerServiceClient) *wallet.Server {
+	return wallet.NewServer(ac, asc, lc, zap.NewNop())
 }
 
 // --- Validation tests ---
 
 func TestDeposit_MissingIdempotencyKey(t *testing.T) {
 	t.Parallel()
-	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+	srv := newTestServer(&mockAccountClient{}, validAssetClient(), &mockLedgerClient{})
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId: "user-1",
 		Amount: 1000,
+		Asset:  "BTC",
 	})
 
 	st, ok := status.FromError(err)
@@ -63,11 +90,12 @@ func TestDeposit_MissingIdempotencyKey(t *testing.T) {
 
 func TestDeposit_MissingUserID(t *testing.T) {
 	t.Parallel()
-	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+	srv := newTestServer(&mockAccountClient{}, validAssetClient(), &mockLedgerClient{})
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		Amount:         1000,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
 	})
 
 	st, ok := status.FromError(err)
@@ -81,12 +109,13 @@ func TestDeposit_MissingUserID(t *testing.T) {
 
 func TestDeposit_ZeroAmount(t *testing.T) {
 	t.Parallel()
-	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+	srv := newTestServer(&mockAccountClient{}, validAssetClient(), &mockLedgerClient{})
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         0,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
 	})
 
 	st, ok := status.FromError(err)
@@ -100,11 +129,31 @@ func TestDeposit_ZeroAmount(t *testing.T) {
 
 func TestDeposit_NegativeAmount(t *testing.T) {
 	t.Parallel()
-	srv := newTestServer(&mockAccountClient{}, &mockLedgerClient{})
+	srv := newTestServer(&mockAccountClient{}, validAssetClient(), &mockLedgerClient{})
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         -500,
+		IdempotencyKey: "key-1",
+		Asset:          "BTC",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("code = %v, want InvalidArgument", st.Code())
+	}
+}
+
+func TestDeposit_MissingAsset(t *testing.T) {
+	t.Parallel()
+	srv := newTestServer(&mockAccountClient{}, validAssetClient(), &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
 		IdempotencyKey: "key-1",
 	})
 
@@ -117,6 +166,31 @@ func TestDeposit_NegativeAmount(t *testing.T) {
 	}
 }
 
+func TestDeposit_UnknownAsset(t *testing.T) {
+	t.Parallel()
+	asc := &mockAssetClient{
+		getAssetFn: func(_ context.Context, _ *assetv1.GetAssetRequest, _ ...grpc.CallOption) (*assetv1.GetAssetResponse, error) {
+			return nil, status.Error(codes.NotFound, "asset not found")
+		},
+	}
+	srv := newTestServer(&mockAccountClient{}, asc, &mockLedgerClient{})
+
+	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         1000,
+		IdempotencyKey: "key-1",
+		Asset:          "DOGE",
+	})
+
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %v", err)
+	}
+	if st.Code() != codes.NotFound {
+		t.Errorf("code = %v, want NotFound", st.Code())
+	}
+}
+
 // --- Downstream error tests ---
 
 func TestDeposit_UserNotFound(t *testing.T) {
@@ -124,15 +198,19 @@ func TestDeposit_UserNotFound(t *testing.T) {
 
 	ac := &mockAccountClient{
 		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+		linkAssetAccountFn: func(_ context.Context, _ *accountv1.LinkAssetAccountRequest, _ ...grpc.CallOption) (*accountv1.LinkAssetAccountResponse, error) {
 			return nil, status.Error(codes.NotFound, "user not found")
 		},
 	}
-	srv := newTestServer(ac, &mockLedgerClient{})
+	srv := newTestServer(ac, validAssetClient(), &mockLedgerClient{})
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "nonexistent",
 		Amount:         1000,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
 	})
 
 	st, ok := status.FromError(err)
@@ -152,12 +230,13 @@ func TestDeposit_AccountServiceInternalError(t *testing.T) {
 			return nil, status.Error(codes.Unavailable, "connection refused")
 		},
 	}
-	srv := newTestServer(ac, &mockLedgerClient{})
+	srv := newTestServer(ac, validAssetClient(), &mockLedgerClient{})
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         1000,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
 	})
 
 	st, ok := status.FromError(err)
@@ -182,12 +261,13 @@ func TestDeposit_LedgerError(t *testing.T) {
 			return nil, status.Error(codes.FailedPrecondition, "overdraft")
 		},
 	}
-	srv := newTestServer(ac, lc)
+	srv := newTestServer(ac, validAssetClient(), lc)
 
 	_, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         1000,
 		IdempotencyKey: "key-1",
+		Asset:          "BTC",
 	})
 
 	st, ok := status.FromError(err)
@@ -212,8 +292,8 @@ func TestDeposit_Success(t *testing.T) {
 			if req.UserId != "user-1" {
 				t.Errorf("GetLedgerAccount user_id = %q, want %q", req.UserId, "user-1")
 			}
-			if req.Asset != wallet.DefaultAsset {
-				t.Errorf("GetLedgerAccount asset = %q, want %q", req.Asset, wallet.DefaultAsset)
+			if req.Asset != "BTC" {
+				t.Errorf("GetLedgerAccount asset = %q, want %q", req.Asset, "BTC")
 			}
 			return &accountv1.GetLedgerAccountResponse{LedgerAccountId: "user:user-1"}, nil
 		},
@@ -227,12 +307,13 @@ func TestDeposit_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	srv := newTestServer(ac, lc)
+	srv := newTestServer(ac, validAssetClient(), lc)
 
 	resp, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         5000,
 		IdempotencyKey: "deposit-key-1",
+		Asset:          "BTC",
 	})
 	if err != nil {
 		t.Fatalf("Deposit: %v", err)
@@ -253,8 +334,8 @@ func TestDeposit_Success(t *testing.T) {
 	if debit.AccountId != wallet.ExternalDepositsAccount {
 		t.Errorf("debit account = %q, want %q", debit.AccountId, wallet.ExternalDepositsAccount)
 	}
-	if debit.Asset != wallet.DefaultAsset {
-		t.Errorf("debit asset = %q, want %q", debit.Asset, wallet.DefaultAsset)
+	if debit.Asset != "BTC" {
+		t.Errorf("debit asset = %q, want %q", debit.Asset, "BTC")
 	}
 	if debit.Amount != -5000 {
 		t.Errorf("debit amount = %d, want %d", debit.Amount, -5000)
@@ -264,11 +345,53 @@ func TestDeposit_Success(t *testing.T) {
 	if credit.AccountId != "user:user-1" {
 		t.Errorf("credit account = %q, want %q", credit.AccountId, "user:user-1")
 	}
-	if credit.Asset != wallet.DefaultAsset {
-		t.Errorf("credit asset = %q, want %q", credit.Asset, wallet.DefaultAsset)
+	if credit.Asset != "BTC" {
+		t.Errorf("credit asset = %q, want %q", credit.Asset, "BTC")
 	}
 	if credit.Amount != 5000 {
 		t.Errorf("credit amount = %d, want %d", credit.Amount, 5000)
+	}
+}
+
+func TestDeposit_LazyLinkSuccess(t *testing.T) {
+	t.Parallel()
+
+	ac := &mockAccountClient{
+		getLedgerAccountFn: func(_ context.Context, _ *accountv1.GetLedgerAccountRequest, _ ...grpc.CallOption) (*accountv1.GetLedgerAccountResponse, error) {
+			// No linked account yet for this asset.
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+		linkAssetAccountFn: func(_ context.Context, req *accountv1.LinkAssetAccountRequest, _ ...grpc.CallOption) (*accountv1.LinkAssetAccountResponse, error) {
+			if req.Asset != "ETH" {
+				t.Errorf("LinkAssetAccount asset = %q, want %q", req.Asset, "ETH")
+			}
+			return &accountv1.LinkAssetAccountResponse{
+				UserId:          req.UserId,
+				Asset:           req.Asset,
+				LedgerAccountId: "user:" + req.UserId,
+			}, nil
+		},
+	}
+	lc := &mockLedgerClient{
+		postTransactionFn: func(_ context.Context, _ *ledgerv1.PostTransactionRequest, _ ...grpc.CallOption) (*ledgerv1.PostTransactionResponse, error) {
+			return &ledgerv1.PostTransactionResponse{
+				Transaction: &ledgerv1.Transaction{Id: "tx-lazy"},
+			}, nil
+		},
+	}
+	srv := newTestServer(ac, validAssetClient(), lc)
+
+	resp, err := srv.Deposit(context.Background(), &walletv1.DepositRequest{
+		UserId:         "user-1",
+		Amount:         2000,
+		IdempotencyKey: "lazy-key-1",
+		Asset:          "ETH",
+	})
+	if err != nil {
+		t.Fatalf("Deposit: %v", err)
+	}
+	if resp.TransactionId != "tx-lazy" {
+		t.Errorf("transaction_id = %q, want %q", resp.TransactionId, "tx-lazy")
 	}
 }
 
@@ -288,12 +411,13 @@ func TestDeposit_IdempotentReplay(t *testing.T) {
 			}, nil
 		},
 	}
-	srv := newTestServer(ac, lc)
+	srv := newTestServer(ac, validAssetClient(), lc)
 
 	req := &walletv1.DepositRequest{
 		UserId:         "user-1",
 		Amount:         1000,
 		IdempotencyKey: "replay-key",
+		Asset:          "BTC",
 	}
 
 	resp1, err := srv.Deposit(context.Background(), req)

--- a/proto/README.md
+++ b/proto/README.md
@@ -7,6 +7,7 @@ This directory will contain the protobuf definitions for all gRPC services.
 - `ledger/` - Ledger service definitions (T1.4)
 - `account/` - Account service definitions (T2.2)
 - `wallet/` - Wallet service definitions (T3.1, T3.2)
+- `asset/` - Asset registry service definitions (T3.4)
 
 ## Generation
 

--- a/proto/account/v1/account.proto
+++ b/proto/account/v1/account.proto
@@ -7,7 +7,7 @@ option go_package = "github.com/CLAM101/exchange-ledger-platform/proto/gen/accou
 import "google/protobuf/timestamp.proto";
 
 service AccountService {
-  // CreateUser registers a new user and auto-links a BTC ledger account.
+  // CreateUser registers a new user.
   // Idempotent: replaying the same idempotency_key returns the existing result.
   rpc CreateUser(CreateUserRequest) returns (CreateUserResponse);
 
@@ -16,6 +16,10 @@ service AccountService {
 
   // GetLedgerAccount returns the ledger account ID for a user and asset pair.
   rpc GetLedgerAccount(GetLedgerAccountRequest) returns (GetLedgerAccountResponse);
+
+  // LinkAssetAccount links a user to a ledger account for a given asset.
+  // Idempotent: linking an already-linked asset returns the existing mapping.
+  rpc LinkAssetAccount(LinkAssetAccountRequest) returns (LinkAssetAccountResponse);
 }
 
 message User {
@@ -47,6 +51,17 @@ message GetLedgerAccountRequest {
 }
 
 message GetLedgerAccountResponse {
+  string user_id = 1;
+  string asset = 2;
+  string ledger_account_id = 3;
+}
+
+message LinkAssetAccountRequest {
+  string user_id = 1;
+  string asset = 2;
+}
+
+message LinkAssetAccountResponse {
   string user_id = 1;
   string asset = 2;
   string ledger_account_id = 3;

--- a/proto/asset/v1/asset.proto
+++ b/proto/asset/v1/asset.proto
@@ -1,0 +1,33 @@
+syntax = "proto3";
+
+package asset.v1;
+
+option go_package = "github.com/CLAM101/exchange-ledger-platform/proto/gen/asset/v1;assetv1";
+
+service AssetService {
+  // GetAsset returns a single asset by symbol.
+  rpc GetAsset(GetAssetRequest) returns (GetAssetResponse);
+
+  // ListAssets returns all registered assets.
+  rpc ListAssets(ListAssetsRequest) returns (ListAssetsResponse);
+}
+
+message Asset {
+  string symbol = 1;
+  int32 decimals = 2;
+  bool active = 3;
+}
+
+message GetAssetRequest {
+  string symbol = 1;
+}
+
+message GetAssetResponse {
+  Asset asset = 1;
+}
+
+message ListAssetsRequest {}
+
+message ListAssetsResponse {
+  repeated Asset assets = 1;
+}

--- a/proto/wallet/v1/wallet.proto
+++ b/proto/wallet/v1/wallet.proto
@@ -12,9 +12,10 @@ service WalletService {
 
 message DepositRequest {
   string user_id = 1;
-  int64 amount = 2; // satoshis, must be > 0
+  int64 amount = 2; // smallest unit (e.g. satoshis), must be > 0
   string reference = 3; // caller-supplied reference
   string idempotency_key = 4;
+  string asset = 5; // e.g. "BTC", "ETH", "USDC"
 }
 
 message DepositResponse {


### PR DESCRIPTION
## Summary
- Introduce in-memory asset registry service (BTC/ETH/USDC) with GetAsset and ListAssets gRPC RPCs
- Add `asset` field to wallet DepositRequest — deposits now validate the asset against the registry
- Implement lazy asset account linking: wallet auto-creates user-asset account mappings on first deposit per asset
- Remove hardcoded `DefaultAsset = "BTC"` from both wallet and account services
- Add LinkAssetAccount RPC to account service, remove auto-link from CreateUser

## Changes
- `proto/asset/v1/asset.proto` — new AssetService with GetAsset/ListAssets RPCs
- `internal/asset/` — domain (Registry interface, InMemoryRegistry), gRPC server, unit + bufconn tests
- `cmd/asset/main.go` — service entry point (gRPC :9004, metrics :9095)
- `proto/wallet/v1/wallet.proto` — add `asset` field to DepositRequest
- `internal/wallet/server.go` — asset validation via asset service, lazy-link on NotFound from GetLedgerAccount
- `proto/account/v1/account.proto` — add LinkAssetAccount RPC
- `internal/account/server.go` — add LinkAssetAccount handler, remove auto-link from CreateUser
- `internal/account/domain.go` — remove DefaultAsset constant
- Config: `docker-compose.yml`, `deploy/prometheus.yml`, `Makefile`, docs

## Test plan
- `go test ./internal/asset/...` — 10 tests (domain, server unit, bufconn integration)
- `go test ./internal/wallet/...` — 13 tests (validation, asset validation, lazy-link, downstream errors, success, idempotency)
- `go test ./internal/account/...` — 17 tests (CreateUser without auto-link, LinkAssetAccount, GetLedgerAccount)
- `make lint` — passes clean
- `make build` — all 6 binaries compile including new asset service

Closes #37